### PR TITLE
Use Ruby 1.8 syntax for method chaining in `importer.rb`

### DIFF
--- a/ruby/import-js/importer.rb
+++ b/ruby/import-js/importer.rb
@@ -101,11 +101,12 @@ module ImportJS
     def camelcase_to_snakecase(string)
       # Grabbed from
       # http://stackoverflow.com/questions/1509915/converting-camel-case-to-underscore-case-in-ruby
-      string.gsub(/::/, '/')
-            .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-            .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-            .tr('-', '_')
-            .downcase
+      string.
+        gsub(/::/, '/').
+        gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').
+        gsub(/([a-z\d])([A-Z])/, '\1_\2').
+        tr('-', '_').
+        downcase
     end
   end
 end


### PR DESCRIPTION
Support for newlines after chained method calls was added to Ruby in
version 1.9.[1](http://ruby.about.com/od/newinruby191/qt/dotsyntaxchange.htm) On my system, the default installation of Vim is using
an older version of Ruby. To support pre-1.9 versions of Ruby, we can
change the placement of the dot in the method calls.

Recent Ruby style guidelines prohibit this syntax,[2](https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains) but in this case
it allows more users to easily try out this Vim plugin.
