### PR TITLE
Remove "ImportJS:" prefix from messages

### DIFF
--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -227,7 +227,7 @@ class Importer {
    * @param {string} str
    */
   message(str) {
-    this.messages.push(`ImportJS: ${str}`);
+    this.messages.push(str);
   }
 
   /**

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -104,7 +104,7 @@ describe('Importer', () => {
       it('displays a message', () => {
         subject();
         expect(result.messages[0]).toMatch(
-          RegExp(`ImportJS: No JS module to import for variable \`${word}\``));
+          RegExp(`No JS module to import for variable \`${word}\``));
       });
     });
 
@@ -124,7 +124,7 @@ foo
       it('displays a message about the imported module', () => {
         subject();
         expect(result.messages[0]).toEqual(
-          'ImportJS: Imported `bar/foo`');
+          'Imported `bar/foo`');
       });
 
       describe('when that import is already imported', () => {
@@ -654,7 +654,7 @@ foo
         it('displays a message about the imported module', () => {
           subject();
           expect(result.messages[0]).toEqual(
-            'ImportJS: Imported `Foo (main: index.jsx)`');
+            'Imported `Foo (main: index.jsx)`');
         });
 
         describe('when that module has a dot in its name', () => {
@@ -708,7 +708,7 @@ fooBar
         it('displays a message about the imported module', () => {
           subject();
           expect(result.messages[0]).toEqual(
-            'ImportJS: Imported `foo-bar (main: foo-bar-main.jsx)`');
+            'Imported `foo-bar (main: foo-bar-main.jsx)`');
         });
 
         describe('with an `ignore_package_prefixes` configuration', () => {
@@ -1316,7 +1316,7 @@ memoize
           it('displays a message about the imported module', () => {
             subject();
             expect(result.messages[0]).toEqual(
-              'ImportJS: Imported `memoize` from `underscore`');
+              'Imported `memoize` from `underscore`');
           });
 
           describe('when the default import exists for the same module', () => {
@@ -1638,7 +1638,7 @@ foo
         it('displays a message', () => {
           subject();
           expect(result.messages[0]).toEqual(
-            `ImportJS: No JS module to import for variable \`${word}\``);
+            `No JS module to import for variable \`${word}\``);
         });
       });
 
@@ -1990,8 +1990,7 @@ foo
 
       it('displays a message', () => {
         subject();
-        expect(result.messages[0]).toEqual(
-          'ImportJS: Added import for `foo`');
+        expect(result.messages[0]).toEqual('Added import for `foo`');
       });
     });
 
@@ -2014,8 +2013,7 @@ foo; bar;
       });
 
       it('displays a message', () => {
-        expect(result.messages[0]).toEqual(
-          'ImportJS: Added 2 imports');
+        expect(result.messages[0]).toEqual('Added 2 imports');
       });
     });
   });


### PR DESCRIPTION
This is leftover from when we only had a Vim plugin. Now that we support
4 editors and hope to support more, it is clear that each editor may
have a different way of displaying this type of information, so we want
to leave this up to each editor plugin to determine what is best.