### PR TITLE
Use relative paths by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ an empty array `[]` to avoid stripping out extensions.
 
 ### `use_relative_paths`
 
-This option is disabled by default. By enabling it, imports will be resolved
+This option is enabled by default. When enabled, imports will be resolved
 relative to the current file being edited.
 
 ```js
@@ -319,8 +319,10 @@ Only imports located in the same `lookup_path` will be made relative to each
 other. Package dependencies (located in `node_modules`) will not be imported
 relatively.
 
+You can disable this by setting it to false:
+
 ```json
-"use_relative_paths": true
+"use_relative_paths": false
 ```
 
 ### `ignore_package_prefixes`

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -28,7 +28,7 @@ const DEFAULT_CONFIG = {
   strip_file_extensions: ['.js', '.jsx'],
   strip_from_path: null,
   tab: '  ',
-  use_relative_paths: false,
+  use_relative_paths: true,
 };
 
 const ENVIRONMENT_CORE_MODULES = {

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1898,7 +1898,7 @@ goo
 
           it('falls back to default config', () => {
             expect(subject()).toEqual(`
-import goo from 'tmp/bar/goo';
+import goo from '../tmp/bar/goo';
 
 goo
             `.trim());
@@ -2389,7 +2389,7 @@ export default function foo() {
     describe('when imports exist', () => {
       beforeEach(() => {
         text = `
-import baz from 'app/baz';
+import baz from '../baz';
 import bar, { foo } from 'bar';
 
 bar
@@ -2401,7 +2401,7 @@ bar
           expect(subject()).toEqual(`
 import bar, { foo } from 'bar';
 
-import baz from 'app/baz';
+import baz from '../baz';
 
 bar
           `.trim());
@@ -2416,7 +2416,7 @@ bar
         it('sorts imports', () => {
           expect(subject()).toEqual(`
 import bar, { foo } from 'bar';
-import baz from 'app/baz';
+import baz from '../baz';
 
 bar
           `.trim());
@@ -2433,7 +2433,7 @@ bar
 const bar = require('bar');
 const { foo } = require('bar');
 
-const baz = require('app/baz');
+const baz = require('../baz');
 
 bar
           `.trim());


### PR DESCRIPTION
Similar to using import as the default declaration keyword (#118), I
think we should use relative paths by default since that is the standard
way of doing things. Using non-relative paths requires a tool like
webpack to be configured in specific ways and should also probably
require additional configuration for ImportJS.

Fixes #186
