### PR TITLE
Break down findJsModulesFor()

### DIFF
--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -73,8 +73,8 @@ class Importer {
   goto(variableName) {
     const jsModules = findJsModulesFor(
       this.config,
-      this.pathToCurrentFile,
-      variableName
+      variableName,
+      this.pathToCurrentFile
     );
 
     const jsModule = this.resolveModuleUsingCurrentImports(
@@ -211,7 +211,7 @@ class Importer {
     oldImports.imports.forEach((imp) => {
       imp.variables().forEach((variable) => {
         const jsModule = this.resolveModuleUsingCurrentImports(
-          findJsModulesFor(this.config, this.pathToCurrentFile, variable),
+          findJsModulesFor(this.config, variable, this.pathToCurrentFile),
           variable
         );
 
@@ -242,8 +242,8 @@ class Importer {
   findOneJsModule(variableName) {
     const jsModules = findJsModulesFor(
       this.config,
-      this.pathToCurrentFile,
-      variableName
+      variableName,
+      this.pathToCurrentFile
     );
 
     if (!jsModules.length) {

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -149,14 +149,13 @@ function findImportsFromLocalFiles(config, variableName, pathToCurrentFile) {
   return matchedModules;
 }
 
-
 /**
  * @param {Configuration} config
- * @param {String} pathToCurrentFile
  * @param {String} variableName
+ * @param {String} pathToCurrentFile
  * @return {Array}
  */
-function findJsModulesFor(config, pathToCurrentFile, variableName) {
+function findJsModulesFor(config, variableName, pathToCurrentFile) {
   const aliasModule = config.resolveAlias(variableName, pathToCurrentFile);
   if (aliasModule) {
     return [aliasModule];

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -169,11 +169,11 @@ function findJsModulesFor(config, pathToCurrentFile, variableName) {
 
   let matchedModules = [];
 
+  matchedModules.push(...findEnvironmentCoreModules(config, variableName));
+  matchedModules.push(...findImportsFromPackageJson(config, variableName));
   matchedModules.push(
     ...findImportsFromLocalFiles(config, variableName, pathToCurrentFile)
   );
-  matchedModules.push(...findEnvironmentCoreModules(config, variableName));
-  matchedModules.push(...findImportsFromPackageJson(config, variableName));
 
   // If you have overlapping lookup paths, you might end up seeing the same
   // module to import twice. In order to dedupe these, we remove the module

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -45,6 +45,17 @@ function formattedToRegex(string) {
 
 /**
  * @param {Configuration} config
+ * @param {String} variableName
+ * @return {Array<JsModule>}
+ */
+function findEnvironmentCoreModules(config, variableName) {
+  return config.environmentCoreModules()
+    .filter(dep => dep.toLowerCase() === variableName.toLowerCase())
+    .map(dep => new JsModule({ importPath: dep }));
+}
+
+/**
+ * @param {Configuration} config
  * @param {String} pathToCurrentFile
  * @param {String} variableName
  * @return {Array}
@@ -116,13 +127,7 @@ function findJsModulesFor(config, pathToCurrentFile, variableName) {
     });
   });
 
-  config.environmentCoreModules().forEach((dep) => {
-    if (dep.toLowerCase() !== variableName.toLowerCase()) {
-      return;
-    }
-
-    matchedModules.push(new JsModule({ importPath: dep }));
-  });
+  matchedModules.push(...findEnvironmentCoreModules(config, variableName));
 
   // Find imports from package.json
   const ignorePrefixes = config.get('ignore_package_prefixes').map(

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -83,25 +83,17 @@ function findImportsFromPackageJson(config, variableName) {
 
 /**
  * @param {Configuration} config
- * @param {String} pathToCurrentFile
  * @param {String} variableName
- * @return {Array}
+ * @param {String} pathToCurrentFile
+ * @return {Array<JsModule>}
  */
-function findJsModulesFor(config, pathToCurrentFile, variableName) {
-  const aliasModule = config.resolveAlias(variableName, pathToCurrentFile);
-  if (aliasModule) {
-    return [aliasModule];
-  }
-
-  const namedImportsModule = config.resolveNamedExports(variableName);
-  if (namedImportsModule) {
-    return [namedImportsModule];
-  }
-
+function findImportsFromLocalFiles(config, variableName, pathToCurrentFile) {
   const formattedVarName = formattedToRegex(variableName);
   const egrepCommand =
     `egrep -i \"(/|^)${formattedVarName}(/index)?(/package)?\.js.*\"`;
-  let matchedModules = [];
+
+  const matchedModules = [];
+
   config.get('lookup_paths').forEach((lookupPath) => {
     if (lookupPath === '') {
       // If lookupPath is an empty string, the `find` command will not work
@@ -145,15 +137,41 @@ function findJsModulesFor(config, pathToCurrentFile, variableName) {
         makeRelativeTo:
           config.get('use_relative_paths', { fromFile: f }) &&
           pathToCurrentFile,
-        stripFromPath:
-          config.get('strip_from_path', { fromFile: f }),
+        stripFromPath: config.get('strip_from_path', { fromFile: f }),
       });
+
       if (module) {
         matchedModules.push(module);
       }
     });
   });
 
+  return matchedModules;
+}
+
+
+/**
+ * @param {Configuration} config
+ * @param {String} pathToCurrentFile
+ * @param {String} variableName
+ * @return {Array}
+ */
+function findJsModulesFor(config, pathToCurrentFile, variableName) {
+  const aliasModule = config.resolveAlias(variableName, pathToCurrentFile);
+  if (aliasModule) {
+    return [aliasModule];
+  }
+
+  const namedImportsModule = config.resolveNamedExports(variableName);
+  if (namedImportsModule) {
+    return [namedImportsModule];
+  }
+
+  let matchedModules = [];
+
+  matchedModules.push(
+    ...findImportsFromLocalFiles(config, variableName, pathToCurrentFile)
+  );
   matchedModules.push(...findEnvironmentCoreModules(config, variableName));
   matchedModules.push(...findImportsFromPackageJson(config, variableName));
 

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -56,10 +56,12 @@ function findEnvironmentCoreModules(config, variableName) {
 
 /**
  * @param {Configuration} config
- * @param {String} formattedVarName
+ * @param {String} variableName
  * @return {Array<JsModule>}
  */
-function findImportsFromPackageJson(config, formattedVarName) {
+function findImportsFromPackageJson(config, variableName) {
+  const formattedVarName = formattedToRegex(variableName);
+
   const ignorePrefixes = config.get('ignore_package_prefixes')
     .map(prefix => escapeRegExp(prefix));
 
@@ -153,7 +155,7 @@ function findJsModulesFor(config, pathToCurrentFile, variableName) {
   });
 
   matchedModules.push(...findEnvironmentCoreModules(config, variableName));
-  matchedModules.push(...findImportsFromPackageJson(config, formattedVarName));
+  matchedModules.push(...findImportsFromPackageJson(config, variableName));
 
   // If you have overlapping lookup paths, you might end up seeing the same
   // module to import twice. In order to dedupe these, we remove the module

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -116,6 +116,14 @@ function findJsModulesFor(config, pathToCurrentFile, variableName) {
     });
   });
 
+  config.environmentCoreModules().forEach((dep) => {
+    if (dep.toLowerCase() !== variableName.toLowerCase()) {
+      return;
+    }
+
+    matchedModules.push(new JsModule({ importPath: dep }));
+  });
+
   // Find imports from package.json
   const ignorePrefixes = config.get('ignore_package_prefixes').map(
     (prefix) => escapeRegExp(prefix));
@@ -137,14 +145,6 @@ function findJsModulesFor(config, pathToCurrentFile, variableName) {
     if (jsModule) {
       matchedModules.push(jsModule);
     }
-  });
-
-  config.environmentCoreModules().forEach((dep) => {
-    if (dep.toLowerCase() !== variableName.toLowerCase()) {
-      return;
-    }
-
-    matchedModules.push(new JsModule({ importPath: dep }));
   });
 
   // If you have overlapping lookup paths, you might end up seeing the same

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -48,7 +48,7 @@ function formattedToRegex(string) {
  * @param {String} variableName
  * @return {Array<JsModule>}
  */
-function findEnvironmentCoreModules(config, variableName) {
+function findImportsFromEnvironment(config, variableName) {
   return config.environmentCoreModules()
     .filter(dep => dep.toLowerCase() === variableName.toLowerCase())
     .map(dep => new JsModule({ importPath: dep }));
@@ -168,7 +168,7 @@ function findJsModulesFor(config, variableName, pathToCurrentFile) {
 
   let matchedModules = [];
 
-  matchedModules.push(...findEnvironmentCoreModules(config, variableName));
+  matchedModules.push(...findImportsFromEnvironment(config, variableName));
   matchedModules.push(...findImportsFromPackageJson(config, variableName));
   matchedModules.push(
     ...findImportsFromLocalFiles(config, variableName, pathToCurrentFile)

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -56,6 +56,31 @@ function findEnvironmentCoreModules(config, variableName) {
 
 /**
  * @param {Configuration} config
+ * @param {String} formattedVarName
+ * @return {Array<JsModule>}
+ */
+function findImportsFromPackageJson(config, formattedVarName) {
+  const ignorePrefixes = config.get('ignore_package_prefixes')
+    .map(prefix => escapeRegExp(prefix));
+
+  const depRegex = RegExp(
+    `^(?:${ignorePrefixes.join('|')})?${formattedVarName}$`
+  );
+
+  return config.packageDependencies()
+    .filter(dep => dep.match(depRegex))
+    .map(dep => (
+      JsModule.construct({
+        lookupPath: 'node_modules',
+        relativeFilePath: `node_modules/${dep}/package.json`,
+        stripFileExtensions: [],
+      })
+    ))
+    .filter(jsModule => !!jsModule);
+}
+
+/**
+ * @param {Configuration} config
  * @param {String} pathToCurrentFile
  * @param {String} variableName
  * @return {Array}
@@ -128,29 +153,7 @@ function findJsModulesFor(config, pathToCurrentFile, variableName) {
   });
 
   matchedModules.push(...findEnvironmentCoreModules(config, variableName));
-
-  // Find imports from package.json
-  const ignorePrefixes = config.get('ignore_package_prefixes').map(
-    (prefix) => escapeRegExp(prefix));
-
-  const depRegex = RegExp(
-    `^(?:${ignorePrefixes.join('|')})?${formattedVarName}$`);
-
-  config.packageDependencies().forEach((dep) => {
-    if (!dep.match(depRegex)) {
-      return;
-    }
-
-    const jsModule = JsModule.construct({
-      lookupPath: 'node_modules',
-      relativeFilePath: `node_modules/${dep}/package.json`,
-      stripFileExtensions: [],
-    });
-
-    if (jsModule) {
-      matchedModules.push(jsModule);
-    }
-  });
+  matchedModules.push(...findImportsFromPackageJson(config, formattedVarName));
 
   // If you have overlapping lookup paths, you might end up seeing the same
   // module to import twice. In order to dedupe these, we remove the module


### PR DESCRIPTION
This function was too big and unwieldy. By breaking it into smaller functions, we can more easily see what is going on.