### PR TITLE
Add babel-plugin-add-module-exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["airbnb"]
+  "presets": ["airbnb"],
+  "plugins": [
+    "add-module-exports"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "babel-cli": "^6.7.7",
     "babel-jest": "^12.0.0",
+    "babel-plugin-add-module-exports": "^0.1.4",
     "babel-preset-airbnb": "^1.1.1",
     "eslint-config-airbnb": "^8.0.0",
     "eslint-plugin-jsx-a11y": "^1.0.2",


### PR DESCRIPTION
This will make it so we can use `export default` style syntax without
the pain of having to specify `.default` when using require, or
switching from require to import. We might eventually want to switch to
use import for lib code, but I imagine that we will continue to use
require in tests, so this seems like a good long-term solution for us.