### PR TITLE
Use export default instead of module.exports

### DIFF
--- a/lib/CommandLineEditor.js
+++ b/lib/CommandLineEditor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class CommandLineEditor {
+export default class CommandLineEditor {
   /**
    * @param {Array<String>} lines
    */
@@ -45,5 +45,3 @@ class CommandLineEditor {
     this._lines.splice(lineNumber, 0, str);
   }
 }
-
-module.exports = CommandLineEditor;

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -77,7 +77,7 @@ const ENVIRONMENT_CORE_MODULES = {
 };
 
 // Class that initializes configuration from a .importjs.json file
-class Configuration {
+export default class Configuration {
   constructor(pathToCurrentFile) {
     this.pathToCurrentFile = this._normalizePath(pathToCurrentFile);
     this.configs = [];
@@ -230,5 +230,3 @@ class Configuration {
     );
   }
 }
-
-module.exports = Configuration;

--- a/lib/FileUtils.js
+++ b/lib/FileUtils.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const FileUtils = {
+export default {
   /**
    * @param {String} file
    * @return {Object?}
@@ -19,5 +19,3 @@ const FileUtils = {
     return JSON.parse(contents);
   },
 };
-
-module.exports = FileUtils;

--- a/lib/ImportStatement.js
+++ b/lib/ImportStatement.js
@@ -51,7 +51,7 @@ const REGEX_NAMED = xRegExp(`
  * `var foo = myCustomRequire('foo');`
  * `import foo from 'foo';`
  */
-class ImportStatement {
+export default class ImportStatement {
   /**
    * @param {String} string a possible import statement, e.g.
    *   `const foo = require('foo');`
@@ -320,5 +320,3 @@ class ImportStatement {
     delete this.originalImportString;
   }
 }
-
-module.exports = ImportStatement;

--- a/lib/ImportStatements.js
+++ b/lib/ImportStatements.js
@@ -44,7 +44,7 @@ GROUPINGS_ARRAY.forEach((group, index) => {
 });
 Object.freeze(GROUPINGS);
 
-class ImportStatements {
+export default class ImportStatements {
   /**
    * @param {Configuration} config
    * @param {Object} imports
@@ -242,5 +242,3 @@ class ImportStatements {
     return PATH_TYPE_NON_RELATIVE;
   }
 }
-
-module.exports = ImportStatements;

--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -23,7 +23,7 @@ function anyNumbersWithinRange(numbers, range) {
   return false;
 }
 
-class Importer {
+export default class Importer {
   constructor(lines, pathToCurrentFile) {
     this.editor = new CommandLineEditor(lines);
     this.config = new Configuration(pathToCurrentFile);
@@ -412,5 +412,3 @@ class Importer {
     return messageParts.join(' ');
   }
 }
-
-module.exports = Importer;

--- a/lib/JsModule.js
+++ b/lib/JsModule.js
@@ -19,7 +19,7 @@ function normalizePath(pathToNormalize) {
 }
 
 // Class that represents a js module found in the file system
-class JsModule {
+export default class JsModule {
   /**
    * @param {String} opts.lookupPath the lookup path in which this module was
    *   found
@@ -200,5 +200,3 @@ class JsModule {
     });
   }
 }
-
-module.exports = JsModule;

--- a/lib/findCurrentImports.js
+++ b/lib/findCurrentImports.js
@@ -26,7 +26,7 @@ const REGEX_SKIP_SECTION = xRegExp(`
  * @param {String} currentFileContent
  * @return {Object}
  */
-function findCurrentImports(config, currentFileContent) {
+export default function findCurrentImports(config, currentFileContent) {
   /* eslint-disable no-cond-assign */
   let importsStartAtLineNumber = 1;
   let newlineCount = 0;
@@ -65,5 +65,3 @@ function findCurrentImports(config, currentFileContent) {
     range: lodashRange(importsStartAtLineNumber, importsEndAtLineNumber),
   };
 }
-
-module.exports = findCurrentImports;

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -155,7 +155,11 @@ function findImportsFromLocalFiles(config, variableName, pathToCurrentFile) {
  * @param {String} pathToCurrentFile
  * @return {Array}
  */
-function findJsModulesFor(config, variableName, pathToCurrentFile) {
+export default function findJsModulesFor(
+  config,
+  variableName,
+  pathToCurrentFile
+) {
   const aliasModule = config.resolveAlias(variableName, pathToCurrentFile);
   if (aliasModule) {
     return [aliasModule];
@@ -183,5 +187,3 @@ function findJsModulesFor(config, variableName, pathToCurrentFile) {
     (module) => module.filePath);
   return sortBy(matchedModules, (module) => module.displayName());
 }
-
-module.exports = findJsModulesFor;

--- a/lib/resolveImportPathAndMain.js
+++ b/lib/resolveImportPathAndMain.js
@@ -61,7 +61,7 @@ function resolveForPackage(filePath) {
  * @param {Array} stripFileExtensions
  * @return {Array<?String, ?String>}
  */
-function resolveImportPathAndMain(filePath, stripFileExtensions) {
+export default function resolveImportPathAndMain(filePath, stripFileExtensions) {
   const resolvedForPackage = resolveForPackage(filePath);
   if (resolvedForPackage) {
     return resolvedForPackage;
@@ -81,5 +81,3 @@ function resolveImportPathAndMain(filePath, stripFileExtensions) {
   const importPath = filePath.replace(RegExp(`(${extensions.join('|')})$`), '');
   return [importPath, null];
 }
-
-module.exports = resolveImportPathAndMain;

--- a/lib/xregexp.js
+++ b/lib/xregexp.js
@@ -4,7 +4,7 @@ const originalXRegExp = require('xregexp');
  * Wrapper for xRegExp to work around
  * https://github.com/slevithan/xregexp/issues/130
  */
-function xRegExp(regexp, flags) {
+export default function xRegExp(regexp, flags) {
   if (!flags || !flags.includes('x')) {
     // We aren't using the 'x' flag, so we don't need to remove comments and
     // whitespace as a workaround for
@@ -21,5 +21,3 @@ function xRegExp(regexp, flags) {
 
 xRegExp.exec = originalXRegExp.exec;
 xRegExp.test = originalXRegExp.test;
-
-module.exports = xRegExp;


### PR DESCRIPTION
I find this syntax to be a little nicer than the module.exports. Now
that we have a babel plugin that enables this, we might as well use it.