### PR TITLE
Make test fail if linting fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint .",
     "prepublish": "npm run clean && npm run build",
     "preversion": "npm run clean && npm test",
-    "test": "npm run --silent lint; npm run --silent jest"
+    "test": "npm run --silent lint && npm run --silent jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Due to how we were using a semicolon to combine two scripts, a failure
to the first command wouldn't cause the entire run to fail. Changing to
&& will make everything fail if the first command fails.