### PR TITLE
Fix using absolute paths for path to current file

### DIFF
--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import escapeRegExp from 'lodash.escaperegexp';
 import eslint from 'eslint';
 
 import CommandLineEditor from './CommandLineEditor';
@@ -27,7 +28,12 @@ export default class Importer {
   constructor(lines, pathToCurrentFile) {
     this.editor = new CommandLineEditor(lines);
     this.config = new Configuration(pathToCurrentFile);
-    this.pathToCurrentFile = pathToCurrentFile;
+
+    // Normalize the path to the current file so that we only have to deal with
+    // local paths.
+    this.pathToCurrentFile = pathToCurrentFile && pathToCurrentFile.replace(
+      RegExp(`^${escapeRegExp(process.cwd())}/`), '');
+
     this.messages = Array.from(this.config.messages);
     this.unresolvedImports = {};
   }

--- a/lib/JsModule.js
+++ b/lib/JsModule.js
@@ -92,16 +92,13 @@ export default class JsModule {
       return;
     }
 
-    // First, strip out any absolute path up until the current directory
-    let makeRelativeTo = makeRelativeToPath.replace(`^${process.cwd()}/`, '');
-
     // Ignore if the file to relate to is part of a different lookupPath
-    if (!makeRelativeTo.startsWith(this.lookupPath)) {
+    if (!makeRelativeToPath.startsWith(this.lookupPath)) {
       return;
     }
 
     // Strip out the lookupPath
-    makeRelativeTo = makeRelativeTo.replace(
+    const makeRelativeTo = makeRelativeToPath.replace(
       RegExp(`^${escapeRegExp(this.lookupPath)}/`), '');
 
     let importPath = path.relative(

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1868,6 +1868,20 @@ foo
             `.trim());
           });
         });
+
+        describe('when the current file is an absolute path in the same lookupPath', () => {
+          beforeEach(() => {
+            pathToCurrentFile = `${process.cwd()}/bar/test.js`;
+          });
+
+          it('uses a relative import path', () => {
+            expect(subject()).toEqual(`
+import foo from './foo';
+
+foo
+            `.trim());
+          });
+        });
       });
 
       describe('with local configuration defined in the main config file', () => {


### PR DESCRIPTION
We had code in place which would strip out the path to the current
directory from the path to the current file. That bit of code wasn't
working, since we were feeding the String.replace with a string instead
of a regexp.

This resulted in relative paths not working correctly in Sublime (which
passes in absolute paths for pathToCurrentFile). We could make that
plugin also pass local paths, but I figured it was worth fixing this in
the main project anyway, because the command-line tool needs to support
these paths.

Fixes #263, which is likely a duplicate of #233.