### PR TITLE
Fix reading file content from stdin

### DIFF
--- a/lib/importjs.js
+++ b/lib/importjs.js
@@ -24,11 +24,11 @@ function getLines(pathToFile, callback) {
     });
     return;
   }
-  const lines = [];
+  const parts = [];
   process.stdin.resume();
   process.stdin.setEncoding('utf-8');
-  process.stdin.on('data', data => lines.push(...data.split('\n')));
-  process.stdin.on('end', () => callback(lines));
+  process.stdin.on('data', data => parts.push(data));
+  process.stdin.on('end', () => callback(parts.join('').split('\n')));
 }
 
 /**


### PR DESCRIPTION
I've been tracking down a bug that from a surface point looked isolated
to only the Sublime plugin. The symptom we've seen is that for large
files, running import-js (`fix` or `word`) would cause an unwanted
line-break to be injected in the middle of the file.

My initial investigation led me into believing that the line-break was
inserted at some point after the command had been run. I based that on
trying the same command in Sublime and from the command-line and seeing
the extra line-break appear in the `stdout` string processed by the
Sublime plugin. Because of that, I went down a few dead ends trying to
find the specific point at which the python code was misbehaving.

What ended up causing this bug was in import-js core code, when parsing
the data passed in from `stdin`. When run from the command-line (using
a pipe to pass data), the entire content is provided in one chunk, or at
least a chunk large enough to not surface the same bug. The Sublime
plugin however, is likely sending down data in multiple chunks.

The fix was fairly simple. We just have to collect all the available
data before splitting it up per line.

Fixes https://github.com/Galooshi/sublime-import-js/issues/3