### PR TITLE
Add Flow

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,8 @@
 {
   "presets": ["es2015"],
   "plugins": [
-    "add-module-exports"
+    "add-module-exports",
+    "transform-flow-strip-types",
+    "transform-class-properties"
   ]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,10 @@
 module.exports = {
+  parser: 'babel-eslint',
+
   plugins: [
+    'flowtype',
+    'flow-vars',
+
     // Although we don't have any React or JSX in this project, we need to have
     // this plugin and some of the rules from this plugin enabled here so that
     // our tests work. We should probably look into a way of doing this so that
@@ -14,5 +19,22 @@ module.exports = {
 
   rules: {
     'no-underscore-dangle': ['error', { allowAfterThis: true }],
-  }
+
+    'flowtype/require-parameter-type': 2,
+    'flowtype/require-return-type': [2, 'always', {
+      annotateUndefined: 'never'
+    }],
+    'flowtype/space-after-type-colon': [2, 'always'],
+    'flowtype/space-before-type-colon': [2, 'never'],
+    'flowtype/type-id-match': [2, "^([A-Z][a-z0-9]+)+Type$"],
+
+    'flow-vars/define-flow-type': 2,
+    'flow-vars/use-flow-type': 2,
+  },
+
+  settings: {
+    flowtype: {
+      onlyFilesWithFlowAnnotation: true,
+    },
+  },
 };

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+module.use_strict=true

--- a/lib/CommandLineEditor.js
+++ b/lib/CommandLineEditor.js
@@ -1,44 +1,27 @@
+// @flow
 export default class CommandLineEditor {
-  /**
-   * @param {Array<String>} lines
-   */
-  constructor(lines) {
+  _lines: Array<string>;
+
+  constructor(lines: Array<string>) {
     this._lines = lines;
   }
 
-  /**
-   * @return {String}
-   */
-  currentFileContent() {
+  currentFileContent(): string {
     return this._lines.join('\n');
   }
 
-  /**
-   * Reads a line from the file.
-   *
-   * @param {Number} index
-   * @return {String}
-   */
-  get(index) {
+  get(index: number): string {
     return this._lines[index];
   }
 
-  /**
-   * Delete a line.
-   *
-   * @param {Number} index
-   */
-  remove(index) {
+  remove(index: number) {
     this._lines.splice(index, 1);
   }
 
   /**
    * Insert a line above the specified index
-   *
-   * @param {Number} index
-   * @param {String} str
    */
-  insertBefore(index, str) {
+  insertBefore(index: number, str: string) {
     this._lines.splice(index, 0, str);
   }
 }

--- a/lib/FileUtils.js
+++ b/lib/FileUtils.js
@@ -1,11 +1,8 @@
+// @flow
 import fs from 'fs';
 
 export default {
-  /**
-   * @param {String} file
-   * @return {Object?}
-   */
-  readJsonFile(file) {
+  readJsonFile(file: string): ?Object {
     if (!fs.existsSync(file)) {
       return null;
     }

--- a/lib/findCurrentImports.js
+++ b/lib/findCurrentImports.js
@@ -1,3 +1,5 @@
+// @flow
+
 import StringScanner from 'StringScanner';
 
 import ImportStatement from './ImportStatement';
@@ -20,12 +22,10 @@ const REGEX_SKIP_SECTION = xRegExp(`
   `, 'xs' // free-spacing, dot-match-all
 );
 
-/**
- * @param {Configuration} config
- * @param {String} currentFileContent
- * @return {Object}
- */
-export default function findCurrentImports(config, currentFileContent) {
+export default function findCurrentImports(
+  config: Object, // TODO change Object to Configuration
+  currentFileContent: string
+): Object {
   /* eslint-disable no-cond-assign */
   let importsStartAt = 0;
   let newlineCount = 0;

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -1,3 +1,5 @@
+// @flow
+
 import escapeRegExp from 'lodash.escaperegexp';
 import minimatch from 'minimatch';
 import sortBy from 'lodash.sortby';
@@ -7,57 +9,52 @@ import findMatchingFiles from './findMatchingFiles';
 import formattedToRegex from './formattedToRegex';
 import JsModule from './JsModule';
 
-/**
- * @param {Configuration} config
- * @param {String} variableName
- * @return {Array<JsModule>}
- */
-function findImportsFromEnvironment(config, variableName) {
+function findImportsFromEnvironment(
+  config: Object, // TODO change Object to Configuration
+  variableName: string
+): Array<JsModule> {
   return config.environmentCoreModules()
-    .filter(dep => dep.toLowerCase() === variableName.toLowerCase())
-    .map(dep => new JsModule({ importPath: dep }));
+    .filter((dep: string): boolean => dep.toLowerCase() === variableName.toLowerCase())
+    .map((dep: string): JsModule => new JsModule({ importPath: dep }));
 }
 
-/**
- * @param {Configuration} config
- * @param {String} variableName
- * @return {Array<JsModule>}
- */
-function findImportsFromPackageJson(config, variableName) {
+function findImportsFromPackageJson(
+  config: Object,
+  variableName: string
+): Array<JsModule> {
   const formattedVarName = formattedToRegex(variableName);
 
   const ignorePrefixes = config.get('ignorePackagePrefixes')
-    .map(prefix => escapeRegExp(prefix));
+    .map((prefix: string): string => escapeRegExp(prefix));
 
   const depRegex = RegExp(
     `^(?:${ignorePrefixes.join('|')})?${formattedVarName}$`
   );
 
   return config.packageDependencies()
-    .filter(dep => dep.match(depRegex))
-    .map(dep => (
+    .filter((dep: string): boolean => depRegex.test(dep))
+    .map((dep: string): ?JsModule => (
       JsModule.construct({
         lookupPath: 'node_modules',
         relativeFilePath: `node_modules/${dep}/package.json`,
         stripFileExtensions: [],
       })
     ))
-    .filter(jsModule => !!jsModule);
+    .filter((jsModule: ?JsModule): boolean => !!jsModule);
 }
 
-/**
- * @param {Configuration} config
- * @param {String} variableName
- * @param {String} pathToCurrentFile
- * @return {Array<JsModule>}
- */
-function findImportsFromLocalFiles(config, variableName, pathToCurrentFile) {
+function findImportsFromLocalFiles(
+  config: Object,
+  variableName: string,
+  pathToCurrentFile: string
+): Array<JsModule> {
   const matchedModules = [];
 
-  config.get('lookupPaths').forEach((lookupPath) => {
-    findMatchingFiles(lookupPath, variableName).forEach((f) => {
-      if (config.get('excludes').some(
-        (globPattern) => minimatch(f, globPattern))) {
+  config.get('lookupPaths').forEach((lookupPath: string) => {
+    findMatchingFiles(lookupPath, variableName).forEach((f: string) => {
+      const isExcluded = config.get('excludes')
+        .some((globPattern: string): boolean => minimatch(f, globPattern));
+      if (isExcluded) {
         return;
       }
 
@@ -81,17 +78,11 @@ function findImportsFromLocalFiles(config, variableName, pathToCurrentFile) {
   return matchedModules;
 }
 
-/**
- * @param {Configuration} config
- * @param {String} variableName
- * @param {String} pathToCurrentFile
- * @return {Array}
- */
 export default function findJsModulesFor(
-  config,
-  variableName,
-  pathToCurrentFile
-) {
+  config: Object,
+  variableName: string,
+  pathToCurrentFile: string
+): Array<JsModule> {
   const aliasModule = config.resolveAlias(variableName, pathToCurrentFile);
   if (aliasModule) {
     return [aliasModule];
@@ -113,9 +104,16 @@ export default function findJsModulesFor(
   // If you have overlapping lookup paths, you might end up seeing the same
   // module to import twice. In order to dedupe these, we remove the module
   // with the longest path
-  matchedModules = sortBy(matchedModules,
-    (module) => module.importPath.length);
-  matchedModules = uniqBy(matchedModules,
-    (module) => module.filePath);
-  return sortBy(matchedModules, (module) => module.displayName());
+  matchedModules = sortBy(
+    matchedModules,
+    (module: JsModule): number => module.importPath.length
+  );
+  matchedModules = uniqBy(
+    matchedModules,
+    (module: JsModule): string => module.filePath
+  );
+  return sortBy(
+    matchedModules,
+    (module: JsModule): string => module.displayName()
+  );
 }

--- a/lib/findMatchingFiles.js
+++ b/lib/findMatchingFiles.js
@@ -1,15 +1,16 @@
+// @flow
+
 import childProcess from 'child_process';
 
 import formattedToRegex from './formattedToRegex';
 
 /**
  * Finds files from the local file system matching the variable name.
- *
- * @param {String} lookupPath
- * @param {String} variableName
- * @return {Array<String>} a list of paths to files that match
  */
-export default function findMatchingFiles(lookupPath, variableName) {
+export default function findMatchingFiles(
+  lookupPath: string,
+  variableName: string
+): Array<string> {
   if (lookupPath === '') {
     // If lookupPath is an empty string, the `find` command will not work
     // as desired so we bail early.
@@ -42,5 +43,5 @@ export default function findMatchingFiles(lookupPath, variableName) {
   }
 
   // Filter out empty lines before returning
-  return out.split('\n').filter(file => file);
+  return out.split('\n').filter((file: string): boolean => !!file);
 }

--- a/lib/formattedToRegex.js
+++ b/lib/formattedToRegex.js
@@ -1,3 +1,5 @@
+// @flow
+
 /**
  * Takes a string in any of the following four formats:
  *   dash-separated
@@ -5,11 +7,8 @@
  *   camelCase
  *   PascalCase
  * and turns it into a regex that you can use to find matching files.
- *
- * @param {String} string
- * @return {String}
  */
-export default function formattedToRegex(string) {
+export default function formattedToRegex(string: string): string {
   // Based on
   // http://stackoverflow.com/questions/1509915/converting-camel-case-to-underscore-case-in-ruby
 

--- a/lib/importjs.js
+++ b/lib/importjs.js
@@ -1,24 +1,21 @@
+// @flow
+
 import fs from 'fs';
 import program from 'commander';
 
 import Importer from './Importer';
 import packageJson from '../package.json';
 
-/**
- * @param {String} str
- */
-function stdoutWrite(str) {
+function stdoutWrite(str: string) {
   process.stdout.write(`${str}\n`);
 }
 
 /**
  * Grab lines from stdin or directly from the file.
- * @param {String} pathToFile
- * @param {Function} callback
  */
-function getLines(pathToFile, callback) {
+function getLines(pathToFile: string, callback: Function) {
   if (process.stdin.isTTY) {
-    fs.readFile(pathToFile, 'utf-8', (err, fileContent) => {
+    fs.readFile(pathToFile, 'utf-8', (err: Error, fileContent: string) => {
       if (err) throw err;
       callback(fileContent.split('\n'));
     });
@@ -27,22 +24,28 @@ function getLines(pathToFile, callback) {
   const parts = [];
   process.stdin.resume();
   process.stdin.setEncoding('utf-8');
-  process.stdin.on('data', data => parts.push(data));
-  process.stdin.on('end', () => callback(parts.join('').split('\n')));
+  process.stdin.on('data', (data: string) => {
+    parts.push(data);
+  });
+  process.stdin.on('end', () => {
+    callback(parts.join('').split('\n'));
+  });
 }
 
 /**
  * Run a command/method on an importer instance
- * @param {Function} executor
- * @param {String} pathToFile
- * @param {Boolean} options.overwrite
  */
-function runCommand(executor, pathToFile, { overwrite }) {
-  getLines(pathToFile, (lines) => {
+type RunCommandOptionsType = { overwrite: boolean };
+function runCommand(
+  executor: Function,
+  pathToFile: string,
+  { overwrite }: RunCommandOptionsType
+) {
+  getLines(pathToFile, (lines: string) => {
     const importer = new Importer(lines, pathToFile);
     const result = executor(importer);
     if (overwrite) {
-      fs.writeFile(pathToFile, result.fileContent, (err) => {
+      fs.writeFile(pathToFile, result.fileContent, (err: Error) => {
         if (err) throw err;
       });
     } else {
@@ -63,32 +66,36 @@ const sharedOptions = {
 
 program.command('word <word> <pathToFile>')
   .option(...sharedOptions.overwrite)
-  .action((word, pathToFile, options) => {
-    runCommand(importer => importer.import(word), pathToFile, options);
+  .action((word: string, pathToFile: string, options: Object) => {
+    const executor = (importer: Importer): Object => importer.import(word);
+    runCommand(executor, pathToFile, options);
   });
 
 program.command('fix <pathToFile>')
   .option(...sharedOptions.overwrite)
-  .action((pathToFile, options) => {
-    runCommand(importer => importer.fixImports(), pathToFile, options);
+  .action((pathToFile: string, options: Object) => {
+    const executor = (importer: Importer): Object => importer.fixImports();
+    runCommand(executor, pathToFile, options);
   });
 
 program.command('rewrite <pathToFile>')
   .option(...sharedOptions.overwrite)
-  .action((pathToFile, options) => {
-    runCommand(importer => importer.rewriteImports(), pathToFile, options);
+  .action((pathToFile: string, options: Object) => {
+    const executor = (importer: Importer): Object => importer.rewriteImports();
+    runCommand(executor, pathToFile, options);
   });
 
 program.command('add <imports> <pathToFile>')
   .option(...sharedOptions.overwrite)
-  .action((imports, pathToFile, options) => {
-    runCommand(importer => importer.addImports(JSON.parse(imports)),
-               pathToFile, options);
+  .action((imports: string, pathToFile: string, options: Object) => {
+    const executor =
+      (importer: Importer): Object => importer.addImports(JSON.parse(imports));
+    runCommand(executor, pathToFile, options);
   });
 
 program.command('goto <word> <pathToFile>')
-  .action((word, pathToFile) => {
-    getLines(pathToFile, (lines) => {
+  .action((word: string, pathToFile: string) => {
+    getLines(pathToFile, (lines: string) => {
       stdoutWrite(JSON.stringify(new Importer(lines, pathToFile).goto(word)));
     });
   });
@@ -104,7 +111,7 @@ program.on('--help', () => {
 
   stdoutWrite('  Examples:');
   stdoutWrite('');
-  examples.forEach(example => {
+  examples.forEach((example: string) => {
     stdoutWrite(`    $ importjs ${example}`);
   });
   stdoutWrite('');

--- a/lib/resolveImportPathAndMain.js
+++ b/lib/resolveImportPathAndMain.js
@@ -1,3 +1,4 @@
+// @flow
 import fs from 'fs';
 import path from 'path';
 
@@ -5,21 +6,13 @@ import escapeRegExp from 'lodash.escaperegexp';
 
 import FileUtils from './FileUtils';
 
-/**
- * @param {String} directory
- * @return {String, null}
- */
-function findIndex(directory) {
-  return ['index.js', 'index.jsx'].find(indexFile => (
+function findIndex(directory: string): string {
+  return ['index.js', 'index.jsx'].find((indexFile: string): boolean => (
     fs.existsSync(`${directory}/${indexFile}`)
   ));
 }
 
-/**
- * @param {String} filePath
- * @return {?Array<?String, ?String>}
- */
-function resolveForPackage(filePath) {
+function resolveForPackage(filePath: string): ?Array<?string> {
   if (!filePath.endsWith('/package.json')) {
     return null;
   }
@@ -31,6 +24,10 @@ function resolveForPackage(filePath) {
 
   let mainFile = json.main;
   const match = filePath.match(/(.*)\/package\.json/);
+  if (!match) {
+    return [null, null];
+  }
+
   const matchPackage = match[1];
 
   if (!mainFile) {
@@ -54,12 +51,10 @@ function resolveForPackage(filePath) {
   return [matchPackage, path.normalize(mainFile)];
 }
 
-/**
- * @param {String} filePath
- * @param {Array} stripFileExtensions
- * @return {Array<?String, ?String>}
- */
-export default function resolveImportPathAndMain(filePath, stripFileExtensions) {
+export default function resolveImportPathAndMain(
+  filePath: string,
+  stripFileExtensions: Array<string>
+): Array<?string> {
   const resolvedForPackage = resolveForPackage(filePath);
   if (resolvedForPackage) {
     return resolvedForPackage;
@@ -75,7 +70,8 @@ export default function resolveImportPathAndMain(filePath, stripFileExtensions) 
   }
 
 
-  const extensions = stripFileExtensions.map(ext => escapeRegExp(ext));
+  const extensions = stripFileExtensions
+    .map((ext: string): string => escapeRegExp(ext));
   const importPath = filePath.replace(RegExp(`(${extensions.join('|')})$`), '');
   return [importPath, null];
 }

--- a/lib/xregexp.js
+++ b/lib/xregexp.js
@@ -1,10 +1,15 @@
+// @flow
+
 import originalXRegExp from 'xregexp';
 
 /**
  * Wrapper for xRegExp to work around
  * https://github.com/slevithan/xregexp/issues/130
  */
-export default function xRegExp(regexp, flags) {
+export default function xRegExp(
+  regexp: string,
+  flags: string
+): RegExp {
   if (!flags || !flags.includes('x')) {
     // We aren't using the 'x' flag, so we don't need to remove comments and
     // whitespace as a workaround for
@@ -14,7 +19,7 @@ export default function xRegExp(regexp, flags) {
 
   const lines = regexp.split('\n');
   return originalXRegExp(
-    lines.map((line) => line.replace(/\s+#.+/, ' ')).join('\n'),
+    lines.map((line: string): string => line.replace(/\s+#.+/, ' ')).join('\n'),
     flags
   );
 }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
   "scripts": {
     "build": "babel lib --out-dir build",
     "clean": "rimraf build",
+    "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "jest": "jest",
     "lint": "eslint .",
     "prepublish": "npm run clean && npm run build",
     "preversion": "npm run clean && npm run build && npm test",
-    "test": "npm run --silent lint && npm run --silent jest"
+    "test": "npm run --silent lint && npm run --silent flow && npm run --silent jest"
   },
   "repository": {
     "type": "git",
@@ -40,12 +41,18 @@
   "homepage": "https://github.com/galooshi/import-js#readme",
   "devDependencies": {
     "babel-cli": "^6.8.0",
+    "babel-eslint": "^6.0.4",
     "babel-jest": "^12.0.0",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-class-properties": "^6.8.0",
+    "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-plugin-flow-vars": "^0.4.0",
+    "eslint-plugin-flowtype": "^2.2.7",
     "eslint-plugin-import": "^1.6.1",
     "eslint-plugin-react": "^5.1.1",
+    "flow-bin": "^0.24.2",
     "jest-cli": "^12.0.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.2"


### PR DESCRIPTION
I'd like to use a static type checker to make our code mode readable and
to help us find bugs before they happen. It seems that our options are
currently Flow or TypeScript. I don't have experience with either
really, so I decided to give Flow a whirl. Since we are already partly
in the Facebook ecosystem with Jest, it seems like this might be a good
bet.

This adds some flow annotations to a few of our files, to see how it
feels. It ended up finding one possible bug already, which is a nice
sign. If we like the direction this is heading, we can expand it to all
of our files, and then eventually remove the `// @flow` pragma and just
have it on automatically.

One somewhat unfortunate downside I ran into was the need to add a Babel
transform for class properties, since Flow requires annotations on class
properties and this is the way it achieves that. This is only
unfortunate because this hasn't been solidified enough in the spec to
make it to stage 3, so it may end up changing dramatically or never
making it into the language officially, which might mean that we'll end
up with some tech debt here. However, I think the tradeoff is worth it
in this case and since we are already going in on a non-standard Flow
syntax, it seems like we might as well do this too.