### PR TITLE
Use `require.resolve` to improve `goto`

### DIFF
--- a/lib/JsModule.js
+++ b/lib/JsModule.js
@@ -6,6 +6,7 @@ import escapeRegExp from 'lodash.escaperegexp';
 
 import Configuration from './Configuration';
 import ImportStatement from './ImportStatement';
+import requireResolve from './requireResolve';
 import resolveImportPathAndMain from './resolveImportPathAndMain';
 
 function normalizePath(pathToNormalize: string): string {
@@ -164,15 +165,9 @@ export default class JsModule {
       return path.resolve(path.dirname(pathToCurrentFile), this.importPath);
     }
 
-    // This is likely an alias that points to a package, so let's try to find
-    // its main file from its package.json file.
-    const filePath = `node_modules/${this.importPath}/package.json`;
-    const main = resolveImportPathAndMain(filePath, [])[1];
-    if (main) {
-      return `node_modules/${this.importPath}/${main}`;
-    }
-
-    return this.importPath;
+    // If all of the above fails to find a path, we fall back to using
+    // require.resolve() to find the file path.
+    return requireResolve(this.importPath);
   }
 
   toImportStatement(

--- a/lib/__mocks__/requireResolve.js
+++ b/lib/__mocks__/requireResolve.js
@@ -1,0 +1,17 @@
+let resolvedPaths;
+
+function __setResolvedPaths(paths: object) {
+  resolvedPaths = paths;
+}
+
+function __reset() {
+  resolvedPaths = {};
+}
+
+__reset();
+
+export default function requireResolve(importPath: string): string {
+  return resolvedPaths[importPath] || importPath;
+}
+requireResolve.__reset = __reset;
+requireResolve.__setResolvedPaths = __setResolvedPaths;

--- a/lib/__tests__/.eslintrc.js
+++ b/lib/__tests__/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
         '__setJsonFile',
         '__setJsonFileFallback',
         '__setVersion',
+        '__setResolvedPaths',
         '__reset',
       ],
       allowAfterThis: true,

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1,9 +1,11 @@
 import FileUtils from '../FileUtils';
 import Importer from '../Importer';
 import findMatchingFiles from '../findMatchingFiles';
+import requireResolve from '../requireResolve';
 
 jest.mock('../FileUtils');
 jest.mock('../findMatchingFiles');
+jest.mock('../requireResolve');
 
 describe('Importer', () => {
   let word;
@@ -48,12 +50,19 @@ describe('Importer', () => {
         return null;
       });
 
+      const resolvedPaths = {};
+      packageDependencies.forEach((dep) => {
+        resolvedPaths[dep] = `node_modules/${dep}/${dep}-main.jsx`;
+      });
+      requireResolve.__setResolvedPaths(resolvedPaths);
+
       findMatchingFiles.__setExistingFiles(existingFiles);
     };
   });
 
   afterEach(() => {
     FileUtils.__reset();
+    requireResolve.__reset();
   });
 
   describe('with deprecated configuration', () => {

--- a/lib/__tests__/JsModule-test.js
+++ b/lib/__tests__/JsModule-test.js
@@ -1,11 +1,14 @@
 import FileUtils from '../FileUtils';
 import JsModule from '../JsModule';
+import requireResolve from '../requireResolve';
 
 jest.mock('../FileUtils');
+jest.mock('../requireResolve');
 
 describe('JsModule', () => {
   afterEach(() => {
     FileUtils.__reset();
+    requireResolve.__reset();
   });
 
   it('does not modify lookupPath when it is .', () => {
@@ -253,13 +256,12 @@ describe('JsModule', () => {
 
     describe('when the import path is a package', () => {
       beforeEach(() => {
-        FileUtils.__setJsonFile(
-          'node_modules/my-package/package.json',
-          { main: 'main-file.js' }
-        );
+        requireResolve.__setResolvedPaths({
+          'my-package': 'node_modules/my-package/main-file.js',
+        });
       });
 
-      it('uses the main file', () => {
+      it('uses the resolved file', () => {
         const jsModule = new JsModule({
           importPath: 'my-package',
         });

--- a/lib/requireResolve.js
+++ b/lib/requireResolve.js
@@ -1,0 +1,14 @@
+/**
+ * Thin wrapper around `require.resolve()` to avoid errors thrown and to make it
+ * easier to mock in tests.
+ */
+export default function requireResolve(importPath: string): string {
+  try {
+    return require.resolve(importPath);
+  } catch (e) {
+    if (/^Cannot find module/.test(e.message)) {
+      return importPath;
+    }
+    throw e;
+  }
+}


### PR DESCRIPTION
This fixes #274.

When you try to go to a module that reside inside a package dependency,
we wouldn't correctly resolve that to the right file path. Example from
the bug report:

  import withGlobal from 'mocha-wrap/withGlobal';

`mocha-wrap` is a package dependency, and the import path should resolve
to `node_modules/mocha-wrap/withGlobal.js`.

By replacing our custom package dependency resolution strategy with
`require.resolve`, we make sure that the right file path is opened.

To make this change easier to test, and to provide better error
handling, I decided to wrap `require.resolve` in our own
`requireResolve` module.

Apart from adding the tests, I've also verified that this works by
trying to go to `shallowCompare` with this import statement:

  const shallowCompare = require('react/lib/shallowCompare');

Before this change, goto would resolve to
`$project_root/react/lib/shallowCompare``. After the change, it's
correctly resolved to
`$project_root/node_modules/react/lib/shallowCompare.js`