### PR TITLE
Fix no tests being run by Jest in Travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
   "jest": {
     "automock": false,
     "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/build/"
+      "<rootDir>/node_modules/",
+      "<rootDir>/build/"
     ]
   }
 }


### PR DESCRIPTION
No tests have been run in Travis CI for a long time. Jest outputs 'No
tests found for ""' in a Travis environment. See e.g.
https://travis-ci.org/Galooshi/import-js/jobs/129367179

  > import-js@0.7.0 test /home/travis/build/Galooshi/import-js
  > npm run --silent lint && npm run --silent jest

  Using Jest CLI v12.0.2, jasmine2, babel-jest
  No tests found for "".
  The command "npm test" exited with 0.
  Done. Your build exited with 0.

@cpojer thought that the problem was a bug that had been fixed in Jest
that broke Jest running in some environments [0]. We tried his suggested
workaround of using `--maxWorkers=1`, but that did not work. When this
bugfix was included in the 12.1.0 release, that also didn't resolve our
problem.

[0]: https://github.com/facebook/jest/commit/8797ecb7

I tracked this down to how we were using testPathIgnorePatterns. You can
read more about my adventures here:

  https://github.com/facebook/jest/issues/1047

TL;DR: testPathIgnorePatterns currently matches against the full path,
not the relative path. Since we included `/build/` and since Travis puts
your code in /home/travis/build/username/repo, all of our tests were
being ignored by Jest when run here.

I've discovered that there is a magic `<repoDir>` token that can be used
to turn these patterns into full paths, which will allow our tests to
run in Travis once again.