### PR TITLE
Strip out cwd from all `goto` paths

### DIFF
--- a/lib/requireResolve.js
+++ b/lib/requireResolve.js
@@ -1,10 +1,13 @@
+import escapeRegExp from 'lodash.escaperegexp';
+
 /**
- * Thin wrapper around `require.resolve()` to avoid errors thrown and to make it
- * easier to mock in tests.
+ * Thin wrapper around `require.resolve()` to avoid errors thrown, normalize
+ * paths, and to make it easier to mock in tests.
  */
 export default function requireResolve(importPath: string): string {
   try {
-    return require.resolve(importPath);
+    const path = require.resolve(importPath);
+    return path.replace(RegExp(`^${escapeRegExp(process.cwd())}`), '');
   } catch (e) {
     if (/^Cannot find module/.test(e.message)) {
       return importPath;


### PR DESCRIPTION
In 03ebfa8, I added code that would use `require.resolve` to find the
file path to a module. While testing this, I was getting relative paths
(e.g. node_modules/react/react.js). When testing again, I'm getting
absolute paths. This might be because of differences in Node versions
(I've been switching between 5.8 and 6.1 for a bit).

Absolute paths are problematic, because consumers of `goto` are
expecting project relative paths. I'm fixing this by simply stripping
out potential `cwd` prefixes before returning.

I think this should resolve the continued problems @ljharb has been
reporting in #274.