### PR TITLE
Speed up findMatchingFilesWithNode by changing ignore pattern

### DIFF
--- a/lib/findMatchingFiles.js
+++ b/lib/findMatchingFiles.js
@@ -39,7 +39,7 @@ function findMatchingFilesWithNode(
   validFilesRegex: string
 ): Array<string> {
   return glob.sync(`${lookupPath}/**/*.js*`, {
-    ignore: './node_modules/**/*',
+    ignore: './node_modules/**',
   }).filter((filePath: string): bool =>
     new RegExp(validFilesRegex, 'i').test(filePath));
 }

--- a/lib/findMatchingFiles.js
+++ b/lib/findMatchingFiles.js
@@ -60,7 +60,7 @@ export default function findMatchingFiles(
   const formattedVarName = formattedToRegex(variableName);
   const validFilesRegex = `(/|^)${formattedVarName}(/index)?(/package)?\\.js.*`;
 
-  if (/^win/.test(process.platform)) {
+  if (/^win/.test(process.platform) || process.env.IMPORT_JS_USE_NODE_FINDER) {
     return findMatchingFilesWithNode(lookupPath, validFilesRegex);
   }
   return findMatchingFilesWithFind(lookupPath, validFilesRegex);


### PR DESCRIPTION
I was poking around in the source code for `glob` and found that you can
make the ignore pattern more efficient by making it end with globstar
'**' [1]. The same files are ignored, it's just that `glob` will avoid
traversing the whole `node_modules` folder (which it seems to have done
before).

This took importjs calls down from 1.4s to 0.7s for the following
command (run from the import-js repo root):

  importjs word glob test.js

[1]: https://github.com/isaacs/node-glob/blob/68f2509d237babec64cf03adf72531127fd80339/common.js#L218