### PR TITLE
Update to ESLint 3

### DIFF
--- a/lib/__tests__/.eslintrc.js
+++ b/lib/__tests__/.eslintrc.js
@@ -17,5 +17,7 @@ module.exports = {
       ],
       allowAfterThis: true,
     }],
+
+    'import/no-extraneous-dependencies': [2, { devDependencies: true }],
   },
 };

--- a/lib/benchmark.js
+++ b/lib/benchmark.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+/* eslint import/no-extraneous-dependencies: [2, { devDependencies: true }] */
 import fs from 'fs';
 import path from 'path';
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "deasync": "^0.1.7",
-    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-config-airbnb-base": "^4.0.0",
     "eslint-plugin-flow-vars": "^0.4.0",
     "eslint-plugin-flowtype": "^2.2.7",
     "eslint-plugin-import": "^1.6.1",
@@ -63,7 +63,7 @@
   "dependencies": {
     "StringScanner": "0.0.3",
     "commander": "^2.9.0",
-    "eslint": "^2.8.0",
+    "eslint": "^3.0.0",
     "fb-watchman": "^1.9.0",
     "glob": "^7.0.3",
     "lodash.escaperegexp": "^4.1.1",


### PR DESCRIPTION
The new eslint configuration enables a rule that we need to tweak
in the context of a few places where it is okay to import
devDependencies.