### PR TITLE
Recognize 'meteor/somepackage' as a package (#305)

### DIFF
--- a/lib/ImportStatements.js
+++ b/lib/ImportStatements.js
@@ -63,11 +63,13 @@ function importStatementPathType(
     return PATH_TYPE_CORE_MODULE;
   }
 
-  // If there is a slash in the path, remove that and everything after it.
-  // This is so that imports for modules inside package dependencies end up
-  // in the right group (PATH_TYPE_PACKAGE).
-  const path = importStatement.path.replace(/^(.*?)\/.*$/, '$1');
-  if (packageDependencies.indexOf(path) !== -1) {
+  // Match if any of the packageDependencies exactly match path or match the
+  // start of the path up to a path divider. This is so that imports for
+  // modules inside package dependencies end up in the right group
+  // (PATH_TYPE_PACKAGE).
+  if (packageDependencies.some((pkg: string): boolean =>
+        importStatement.path === pkg ||
+        importStatement.path.startsWith(`${pkg}/`))) {
     return PATH_TYPE_PACKAGE;
   }
 


### PR DESCRIPTION
In importStatemetnPathType, the lines
```js
  const path = importStatement.path.replace(/^(.*?)\/.*$/, '$1');
  if (packageDependencies.indexOf(path) !== -1) {
```
strip a meteor package path such as 'meteor/aldeed:simple-schema' down to nothing but 'meteor' and then fail to match the package name contained in the packageDependencies array.

The regex line was placed there to allow imports for modules inside packages to be properly placed in the package group.

Rather than change the regex to skip the 'meteor/' prefix, I have chosen in this change to eliminate the need for the regex by matching the packageDepencies against either the whole path or the start of the path up to a path divider as shown below.
```js
  if (packageDependencies.some((pkg: string): boolean =>
        importStatement.path === pkg ||
        importStatement.path.startsWith(`${pkg}/`))) {
```
This should fix the problem in a fashion that is not Meteor specific.