### PR TITLE
Add tests for meteor package recognition (#305)

### DIFF
--- a/lib/__tests__/ImportStatements-test.js
+++ b/lib/__tests__/ImportStatements-test.js
@@ -106,6 +106,7 @@ describe('ImportStatements', () => {
       beforeEach(() => {
         FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
           environments: ['meteor'],
+          packageDependencies: ['meteor/bar'],
         });
       });
 
@@ -132,6 +133,30 @@ describe('ImportStatements', () => {
           "import { Meteor } from 'meteor/meteor';",
           '',
           "import { SimpleSchema } from 'meteor/aldeed:simple-schema';",
+        ]);
+      });
+
+      it('separates package dependencies from non-package dependencies', () => {
+        const statements = new ImportStatements(new Configuration());
+        statements.push(ImportStatement.parse("import foo from 'foo';"));
+        statements.push(ImportStatement.parse("import bar from 'meteor/bar';"));
+
+        expect(statements.toArray()).toEqual([
+          "import bar from 'meteor/bar';",
+          '',
+          "import foo from 'foo';",
+        ]);
+      });
+
+      it('separates package module dependencies from non-package dependencies', () => {
+        const statements = new ImportStatements(new Configuration());
+        statements.push(ImportStatement.parse("import foo from 'foo';"));
+        statements.push(ImportStatement.parse("import bar from 'meteor/bar/too/far';"));
+
+        expect(statements.toArray()).toEqual([
+          "import bar from 'meteor/bar/too/far';",
+          '',
+          "import foo from 'foo';",
         ]);
       });
     });


### PR DESCRIPTION
This commit in response to [lencioni's request](https://github.com/Galooshi/import-js/pull/306#issuecomment-232220379) augments the tests to verify that future changes don't break the fix to package recognition that was added in response to #305.

Two tests were added.

The first verifies that Meteor package dependencies which contain slashes,  "meteor/aldeed:simple-schema", are recognized as packages and separated from non-package dependences.

The second verifies that they are still recognized as packages when the path includes a path to a module inside of the package, i.e. "meteor/aldeed:simple-schema/validate".