### PR TITLE
Implement meteor environment's packageDependencies

### DIFF
--- a/lib/__tests__/Configuration-test.js
+++ b/lib/__tests__/Configuration-test.js
@@ -1,4 +1,5 @@
 /* global spyOn */
+import fs from 'fs';
 import path from 'path';
 
 import Configuration from '../Configuration';
@@ -7,9 +8,11 @@ import version from '../version';
 
 jest.mock('../FileUtils');
 jest.mock('../version');
+jest.mock('fs');
 
 describe('Configuration', () => {
   afterEach(() => {
+    fs.__reset();
     FileUtils.__reset();
     version.__reset();
   });
@@ -521,6 +524,32 @@ describe('Configuration', () => {
           expect(new Configuration().get('packageDependencies'))
             .toEqual(['foo', 'bar']);
         });
+      });
+    });
+
+    describe('in Meteor environment with package dependencies', () => {
+      beforeEach(() => {
+        fs.__setFile(path.join(process.cwd(), '.meteor/packages'), `
+# comment to be ignored
+   john:foo-bar  # has leading white space
+check # core package to be ignored
+jane:bar-foo@1.0.0   # version to be stripped
+          `.trim(),
+          { isDirectory: () => false }
+        );
+        FileUtils.__setFile(path.join(process.cwd(), 'package.json'), {
+          dependencies: {
+            foo: '1.0.0',
+            bar: '2.0.0',
+          },
+        });
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'),
+          { environments: ['meteor'] });
+      });
+
+      it('returns an array of Meteor and npm dependencies', () => {
+        expect(new Configuration().get('packageDependencies'))
+          .toEqual(['meteor/john:foo-bar', 'meteor/jane:bar-foo', 'foo', 'bar']);
       });
     });
   });

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -61,7 +61,7 @@ function meteorPackageDependencies(
     // add 'meteor/' to the start of each name per Meteor convention
     .map((pkg: string) => `meteor/${pkg.trimLeft()}`)
     // eliminate those packages that are considered to be core
-    .filter((pkg: string) => !coreModules.includes(pkg));
+    .filter((pkg: string) => coreModules.indexOf(pkg) === -1);
   return packages;
 }
 

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -29,6 +29,32 @@ function meteorPackageDependencies(
   if (!fs.existsSync(meteorPackagesPath)) {
     return [];
   }
+  // Meteor is an "app" framework. As such, it has both apps and packages. When working with a
+  // module that is part of an app, the list of Meteor packages that a module may import is found in
+  // '.meteor/packages'. This file is actually called a ProjectConstraintsFile in the meteor code.
+  // The internal meteor routine that parses it may be found at
+  // https://github.com/meteor/meteor/blob/f8b1bba606678303ea4e82b8da7c8ae0683b0b7c/tools/project-context.js#L841.
+  // After reverse engineering ProjectConstraintsFile.prototype._readfile at that location, the
+  // following appears to be the pertinent facts for any parser.
+  //  - the only true information within the file is a list of constraints
+  //  - a constraint may not span a line
+  //  - only one constraint may appear on a line
+  //  - a constraint consists of a package name and an optional version constraint separated by
+  //    the '@' symbol
+  //  - white space may not appear within a constraint
+  //  - the '#' symbol signifies that the rest of the line is a comment
+  //  - all white space is ignored
+  //  - package names
+  //      - are allowed to contain [a-z0-9:.\-]
+  //      - must have at least one lowercase letter
+  //      - may not begin or end with a dot or colon
+  //      - may not begin with a hyphen
+  //      - may not contain two consecutive dots
+  //
+  // This routine is only interested in extracting the package names and has no concern for
+  // precisely validating them. An assumption is made that the file is basically valid.
+  // Thus, they may be extracted with a simple global, multiline match of characters allowed
+  // to be in a package name that are at the beginning of a line, possibly following white space.
   const packages = fs.readFileSync(meteorPackagesPath, 'utf8')
     // extract an array of package names from the packages file
     .match(/^\s*([^# @\n]+)/gm)

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -56,10 +56,10 @@ function meteorPackageDependencies(
   // Thus, they may be extracted with a simple global, multiline match of characters allowed
   // to be in a package name that are at the beginning of a line, possibly following white space.
   const packages = fs.readFileSync(meteorPackagesPath, 'utf8')
-    // extract an array of package names from the packages file
-    .match(/^\s*([^# @\n]+)/gm)
+    // extract an array of package names (possibly with preceding whitespace) from the packages file
+    .match(/^\s*[a-z0-9:.\-]+/gm)
     // add 'meteor/' to the start of each name per Meteor convention
-    .map((pkg: string) => `meteor/${pkg}`)
+    .map((pkg: string) => `meteor/${pkg.trimLeft()}`)
     // eliminate those packages that are considered to be core
     .filter((pkg: string) => !coreModules.includes(pkg));
   return packages;

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -1,22 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+
+import findPackageDependencies from '../findPackageDependencies';
+
+const coreModules = [
+  'meteor/accounts-base',
+  'meteor/blaze',
+  'meteor/check',
+  'meteor/ddp-client',
+  'meteor/ddp-rate-limiter',
+  'meteor/ejson',
+  'meteor/email',
+  'meteor/http',
+  'meteor/check',
+  'meteor/meteor',
+  'meteor/mongo',
+  'meteor/random',
+  'meteor/reactive-var',
+  'meteor/session',
+  'meteor/templating',
+  'meteor/tracker',
+];
+
+function meteorPackageDependencies(
+  { config }: Object
+): Array<string> {
+  const meteorPackagesPath = path.join(config.workingDirectory, '.meteor/packages');
+  if (!fs.existsSync(meteorPackagesPath)) {
+    return [];
+  }
+  const packages = fs.readFileSync(meteorPackagesPath, 'utf8')
+    // extract an array of package names from the packages file
+    .match(/^\s*([^# @\n]+)/gm)
+    // add 'meteor/' to the start of each name per Meteor convention
+    .map((pkg: string) => `meteor/${pkg}`)
+    // eliminate those packages that are considered to be core
+    .filter((pkg: string) => !coreModules.includes(pkg));
+  return packages;
+}
+
 export default {
-  coreModules: [
-    'meteor/accounts-base',
-    'meteor/blaze',
-    'meteor/check',
-    'meteor/ddp-client',
-    'meteor/ddp-rate-limiter',
-    'meteor/ejson',
-    'meteor/email',
-    'meteor/http',
-    'meteor/check',
-    'meteor/meteor',
-    'meteor/mongo',
-    'meteor/random',
-    'meteor/reactive-var',
-    'meteor/session',
-    'meteor/templating',
-    'meteor/tracker',
-  ],
+  coreModules,
 
   namedExports: {
     'meteor/accounts-base': ['AccountsClient', 'Accounts', 'AccountsServer'],
@@ -35,4 +59,11 @@ export default {
     'meteor/templating': ['Template'],
     'meteor/tracker': ['Tracker'],
   },
+
+  packageDependencies: ({ config }: Object): Array<String> =>
+    meteorPackageDependencies({ config })
+      // add NPM packages to the list
+      .concat(findPackageDependencies(
+        config.workingDirectory,
+        config.get('importDevDependencies'))),
 };


### PR DESCRIPTION
Meteor includes two package systems, its own and support for NPM packages. Currently, only NPM packages are being recognized as such by the default packageDependencies implementation.

This submission builds on #303 which allows environment configurations to supply a packageDependencies function.

A packageDependencies function is added to environments/meteorEnvironment.js. It returns a list that is a combination of Meteor packages extracted from the .meteor/packages file and NPM packages found via the existing findPackageDependencies function.