### PR TITLE
Auto-create namedExports for Meteor packages using metadata

### DIFF
--- a/lib/__tests__/Configuration-test.js
+++ b/lib/__tests__/Configuration-test.js
@@ -1,5 +1,6 @@
 /* global spyOn */
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import Configuration from '../Configuration';
@@ -435,6 +436,111 @@ describe('Configuration', () => {
       });
     });
   });
+
+  describe('#get namedExports from meteor environment', () => {
+    beforeEach(() => {
+      FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+        environments: ['meteor'],
+      });
+      fs.__setFile(path.join(process.cwd(), '.meteor', 'packages'), `
+john:foo
+jane:bar
+        `.trim(),
+        { isDirectory: () => false }
+      );
+      fs.__setFile(path.join(process.cwd(), '.meteor', 'versions'), `
+john:foo@1.0.0
+jane:bar@0.0.1
+        `.trim(),
+        { isDirectory: () => false }
+      );
+      FileUtils.__setFile(
+        path.join(os.homedir(), '.meteor', 'packages', 'john_foo', '1.0.0', 'isopack.json'),
+        {
+          name: 'foo',
+          summary: 'Metasyntactic package name #1',
+          version: '1.0.0',
+          isTest: false,
+          'isopack-2': {
+            builds: [
+              {
+                kind: 'main',
+                arch: 'os',
+                path: 'os.json',
+              },
+            ],
+          },
+        }
+      );
+      FileUtils.__setFile(
+        path.join(os.homedir(), '.meteor', 'packages', 'john_foo', '1.0.0', 'os.json'),
+        {
+          format: 'isopack-2-unibuild',
+          declaredExports: [
+            {
+              name: 'foosball',
+              testOnly: false,
+            },
+          ],
+        }
+      );
+      FileUtils.__setFile(
+        path.join(process.cwd(), '.meteor', 'local', 'isopacks', 'jane_bar', 'isopack.json'),
+        {
+          name: 'bar',
+          summary: 'Metasyntactic package name #2',
+          version: '0.0.1',
+          isTest: false,
+          'isopack-2': {
+            builds: [
+              {
+                kind: 'main',
+                arch: 'os',
+                path: 'os.json',
+              },
+            ],
+          },
+        }
+      );
+      FileUtils.__setFile(
+        path.join(process.cwd(), '.meteor', 'local', 'isopacks', 'jane_bar', 'os.json'),
+        {
+          format: 'isopack-2-unibuild',
+          declaredExports: [
+            {
+              name: 'barsketball',
+              testOnly: false,
+            },
+          ],
+        }
+      );
+    });
+
+    it('extracts namedExports and merges them into a single object', () => {
+      expect(new Configuration().get('namedExports')).toEqual({
+        // These namedExports are the core ones that are always returned for Meteor
+        'meteor/accounts-base': ['AccountsClient', 'Accounts', 'AccountsServer'],
+        'meteor/blaze': ['Blaze'],
+        'meteor/check': ['check', 'Match'],
+        'meteor/ddp-client': ['DDP'],
+        'meteor/ddp-rate-limiter': ['DDPRateLimiter'],
+        'meteor/ejson': ['EJSON'],
+        'meteor/email': ['Email'],
+        'meteor/http': ['HTTP'],
+        'meteor/meteor': ['Meteor'],
+        'meteor/mongo': ['Mongo'],
+        'meteor/random': ['Random'],
+        'meteor/reactive-var': ['ReactiveVar'],
+        'meteor/session': ['Session'],
+        'meteor/templating': ['Template'],
+        'meteor/tracker': ['Tracker'],
+        // These namedExports should be extracted from the Meteor metadata
+        'meteor/john:foo': ['foosball'],
+        'meteor/jane:bar': ['barsketball'],
+      });
+    });
+  });
+
 
   describe('#get lookupPaths', () => {
     beforeEach(() => {

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1962,6 +1962,111 @@ foo
         });
       });
 
+      describe('in a meteor environment', () => {
+        beforeEach(() => {
+          configuration.environments = ['meteor'];
+          existingFiles = ['bar/foo.jsx'];
+          text = 'foo';
+          configuration.lookupPaths = ['bar'];
+        });
+
+        describe('with `useRelativePaths=true`', () => {
+          beforeEach(() => {
+            configuration.useRelativePaths = true;
+          });
+
+          describe('when the current file is in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = 'bar/current.js';
+            });
+
+            it('uses a relative import path', () => {
+              expect(subject()).toEqual(`
+import foo from './foo';
+
+foo
+              `.trim());
+            });
+          });
+
+          describe('when the current file is not in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = '/foo/bar/current.js';
+            });
+
+            it('does not use a relative import path', () => {
+              expect(subject()).toEqual(`
+import foo from '/foo';
+
+foo
+              `.trim());
+            });
+          });
+
+          describe('when the current file is an absolute path in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = `${process.cwd()}/bar/test.js`;
+            });
+
+            it('uses a relative import path', () => {
+              expect(subject()).toEqual(`
+import foo from './foo';
+
+foo
+              `.trim());
+            });
+          });
+        });
+
+        describe('with `useRelativePaths=false`', () => {
+          beforeEach(() => {
+            configuration.useRelativePaths = false;
+          });
+
+          describe('when the current file is in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = 'bar/current.js';
+            });
+
+            it('uses an absolute import path', () => {
+              expect(subject()).toEqual(`
+import foo from '/foo';
+
+foo
+              `.trim());
+            });
+          });
+
+          describe('when the current file is not in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = '/foo/bar/current.js';
+            });
+
+            it('does not use a relative import path', () => {
+              expect(subject()).toEqual(`
+import foo from '/foo';
+
+foo
+              `.trim());
+            });
+          });
+
+          describe('when the current file is an absolute path in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = `${process.cwd()}/bar/test.js`;
+            });
+
+            it('does not use a relative import path', () => {
+              expect(subject()).toEqual(`
+import foo from '/foo';
+
+foo
+              `.trim());
+            });
+          });
+        });
+      });
+
       describe('with `useRelativePaths=true`', () => {
         beforeEach(() => {
           existingFiles = ['bar/foo.jsx'];

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -78,26 +78,30 @@ function meteorPackageDependencies(
   // precisely validating them. An assumption is made that the file is basically valid.
   // Thus, they may be extracted with a simple global, multiline match of characters allowed
   // to be in a package name that are at the beginning of a line, possibly following white space.
-  const packages: Array<String> = fs.readFileSync(meteorPackagesPath, 'utf8')
+  const packages: Array<string> = fs.readFileSync(meteorPackagesPath, 'utf8')
     // extract an array of package names (possibly with preceding whitespace) from the packages file
     .match(/^\s*[a-z0-9:.\-]+/gm)
     // add 'meteor/' to the start of each name per Meteor convention
-    .map((pkg: String): String => `meteor/${pkg.trimLeft()}`)
+    .map((pkg: string): string => `meteor/${pkg.trimLeft()}`)
     // eliminate those packages that are considered to be core
-    .filter((pkg: string) => coreModules.indexOf(pkg) === -1);
+    .filter((pkg: string): boolean => coreModules.indexOf(pkg) === -1);
   return packages;
 }
 
 function meteorPackageNamedExports({ config }: Object): Object {
-  // This function seeks to extract the named exports from all non-core, 3rd party meteor packages
-  // being utilized in the application. The meteorPackageDependencies function identifies that
-  // list of packages.
+  // This function seeks to extract the named exports from all non-core, 3rd party or local meteor
+  // packages being utilized in the application. The meteorPackageDependencies function identifies
+  // that list of packages.
   //
-  // 3rd party packages are deployed as "isopacks". These can usually be found within the meteor
-  // warehouse directory on the system at ~/.meteor/packages. These isopacks do not exactly
-  // contain the original package source. In particular, they are always missing a "package.js"
-  // file. This is important to us because it is the one that specifies the interface. They do
-  // however contain build products that resulted from that specification.
+  // Meteor packages are deployed as "isopacks". These can usually be found within the meteor
+  // warehouse directory on the system at ~/.meteor/packages. isopacks for local Meteor packages,
+  // i.e. those whose source is in the <project-root>/packages directory, can usually be found in
+  // at <project-root>/.meteor/local/isopacks.
+  //
+  // These isopacks do not exactly contain the original package source. In particular, they are
+  // always missing a "package.js" file. This is important to us because it is the one that
+  // specifies the interface. They do however contain build products that resulted from that
+  // specification.
   //
   // Meteor is an isomorphic environment. An isopack contains multiple builds, one for each
   // targeted platform. Typically, this will include at least a client and a server build.  An
@@ -189,13 +193,13 @@ function meteorPackageNamedExports({ config }: Object): Object {
   const pkgVersionPairs: Array<string> = fs.readFileSync(meteorVersionsPath, 'utf8')
     .match(/^[^@\s]+@[^\s]+$/gm);
   for (const pkgVersionPair of pkgVersionPairs) {
-    const [pkg: String, version: String] = pkgVersionPair.split('@');
+    const [pkg, version] = pkgVersionPair.split('@');
     pkgVersions.set(pkg, version);
   }
 
   // Try to identify the exports of all packages identified by meteorPackageDependencies
-  const namedExports: Object = {};
-  const meteorPackagesDir: String = path.join(os.homedir(), '.meteor/packages');
+  const namedExports = {};
+  const meteorPackagesDir = path.join(os.homedir(), '.meteor/packages');
   for (const meteorPkg of meteorPackageDependencies({ config })) {
     // The isopack's are usually found at
     //   ~/.meteor/packages/<pkg>/<pkgVersion>
@@ -203,15 +207,21 @@ function meteorPackageNamedExports({ config }: Object): Object {
     //       underlines.
 
     // Strip 'meteor/' off the front of the meteorPkg
-    const pkg: String = meteorPkg.slice(7);
-    const pkgVersion: String = pkgVersions.get(pkg);
-    const isopackRoot: String = path.join(meteorPackagesDir, pkg.replace(':', '_'), pkgVersion);
-    const isopackPath: String = path.join(isopackRoot, 'isopack.json');
+    const pkg = meteorPkg.slice(7);
+    const pkgVersion = pkgVersions.get(pkg);
+    let isopackRoot = path.join(meteorPackagesDir, pkg.replace(':', '_'), pkgVersion);
+    let isopackPath = path.join(isopackRoot, 'isopack.json');
     if (!fs.existsSync(isopackPath)) {
-      // Can't get anywhere without the main isopack.json. Go to the next package.
-      continue;
+      // It is possible that this is a local package as opposed to a 3rd party package. If so, it's
+      // isopack may be in <project-root>/.meteor/isopacks/<pkg>.
+      isopackRoot = path.join(config.workingDirectory, '.meteor', 'local', 'isopacks', pkg);
+      isopackPath = path.join(isopackRoot, 'isopack.json');
+      if (!fs.existsSync(isopackPath)) {
+        // Can't get anywhere without the main isopack.json. Go to the next package.
+        continue;
+      }
     }
-    const isopack: Object = FileUtils.readJsonFile(isopackPath);
+    const isopack = FileUtils.readJsonFile(isopackPath);
     if (!isopack) {
       // Can't get anywhere without the main isopack.json. Go to the next package.
       continue;
@@ -227,9 +237,9 @@ function meteorPackageNamedExports({ config }: Object): Object {
     }
     // We can't guess which build the current module is being included in. So, we'll find all
     // declaredExports from all builds and combine them into one namedExports specification.
-    const declaredExports: Array<String> = [];
+    const declaredExports: Array<string> = [];
     for (const build of isopackVer.builds) {
-      const buildIsopackPath: String = path.join(isopackRoot, build.path);
+      const buildIsopackPath = path.join(isopackRoot, build.path);
       if (!fs.existsSync(buildIsopackPath)) {
         // Something is wrong with this build. Try the next one.
         continue;
@@ -242,7 +252,7 @@ function meteorPackageNamedExports({ config }: Object): Object {
       for (const declaredExport of buildIsopack.declaredExports) {
         // If this declaredExport is not a "testOnly" export and is not already amongst those we've
         // gathered, push it into our collection.
-        if (!declaredExport.testOnly && !declaredExports.includes(declaredExport.name)) {
+        if (!declaredExport.testOnly && declaredExports.indexOf(declaredExport.name) === -1) {
           declaredExports.push(declaredExport.name);
         }
       }
@@ -270,7 +280,7 @@ export default {
     return allNamedExports;
   },
 
-  packageDependencies: ({ config }: Object): Array<String> =>
+  packageDependencies: ({ config }: Object): Array<string> =>
     meteorPackageDependencies({ config })
       // add NPM packages to the list
       .concat(findPackageDependencies(

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -211,21 +211,20 @@ function meteorPackageNamedExports({ config }: Object): Object {
     const pkgVersion = pkgVersions.get(pkg) || '';
     let isopackRoot = path.join(meteorPackagesDir, pkg.replace(':', '_'), pkgVersion);
     let isopackPath = path.join(isopackRoot, 'isopack.json');
-    if (!fs.existsSync(isopackPath)) {
+    let isopack = FileUtils.readJsonFile(isopackPath);
+    if (!isopack) {
       // It is possible that this is a local package as opposed to a 3rd party package. If so, it's
       // isopack may be in <project-root>/.meteor/isopacks/<pkg>.
-      isopackRoot = path.join(config.workingDirectory, '.meteor', 'local', 'isopacks', pkg);
+      isopackRoot = path.join(
+        config.workingDirectory, '.meteor', 'local', 'isopacks', pkg.replace(':', '_'));
       isopackPath = path.join(isopackRoot, 'isopack.json');
-      if (!fs.existsSync(isopackPath)) {
+      isopack = FileUtils.readJsonFile(isopackPath);
+      if (!isopack) {
         // Can't get anywhere without the main isopack.json. Go to the next package.
         continue;
       }
     }
-    const isopack = FileUtils.readJsonFile(isopackPath);
-    if (!isopack) {
-      // Can't get anywhere without the main isopack.json. Go to the next package.
-      continue;
-    }
+
     // isopack.json often contains separate sections for every version of the isopacks that
     // has ever been made available. We're only interested in isopack-2 or isopack-1 at this
     // time. Prefer the newer isopack-2 specification if available
@@ -240,13 +239,13 @@ function meteorPackageNamedExports({ config }: Object): Object {
     const declaredExports: Array<string> = [];
     for (const build of isopackVer.builds) {
       const buildIsopackPath = path.join(isopackRoot, build.path);
-      if (!fs.existsSync(buildIsopackPath)) {
+      const buildIsopack = FileUtils.readJsonFile(buildIsopackPath);
+      if (!buildIsopack) {
         // Something is wrong with this build. Try the next one.
         continue;
       }
-      const buildIsopack = FileUtils.readJsonFile(buildIsopackPath);
       if (!buildIsopack || !buildIsopack.declaredExports) {
-        // This build has no declaedExports. Try the next one.
+        // Either this build is missing or it has no declaredExports. Try the next one.
         continue;
       }
       for (const declaredExport of buildIsopack.declaredExports) {

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -88,11 +88,36 @@ function meteorPackageDependencies(
   return packages;
 }
 
-function meteorPackageNamedExports({ config }: Object): Object {
-  // This function seeks to extract the named exports from all non-core, 3rd party or local meteor
-  // packages being utilized in the application. The meteorPackageDependencies function identifies
-  // that list of packages.
-  //
+function meteorPackageVersions(projectRootDir: string): ?Map<string, string> {
+  // This function processes all of the package versions found in .meteor/versions and returns
+  // a map containing them.
+
+  const meteorVersionsPath = path.join(projectRootDir, '.meteor/versions');
+  if (!fs.existsSync(meteorVersionsPath)) {
+    // If we're even in an application directory, it must be broken. In any case, we can't
+    // find the packages without their versions. Return null to indicate that an issue
+    // occurred as opposed to processing an empty .meteor/versions.
+    return null;
+  }
+  const pkgVersions = new Map();
+  const pkgVersionPairs: Array<string> = fs.readFileSync(meteorVersionsPath, 'utf8')
+    .match(/^[^@\s]+@[^\s]+$/gm) || [];
+  for (const pkgVersionPair of pkgVersionPairs) {
+    const [pkg, version] = pkgVersionPair.split('@');
+    pkgVersions.set(pkg, version);
+  }
+  return pkgVersions;
+}
+
+function extractExportsFromMeteorPackage(
+  projectRootDir: string,
+  pkg: string,
+  pkgVersion: string
+): ?Array<string> {
+  // This function extracts the named exports from the package specified by pkg and pkgVersion
+  // and returns them as an array of strings. If null is returned, a problem was encountered
+  // in processing. If an empty array is returned, no named exports were found.
+
   // Meteor packages are deployed as "isopacks". These can usually be found within the meteor
   // warehouse directory on the system at ~/.meteor/packages. isopacks for local Meteor packages,
   // i.e. those whose source is in the <project-root>/packages directory, can usually be found in
@@ -179,89 +204,80 @@ function meteorPackageNamedExports({ config }: Object): Object {
   // achieve this. If its using CommonJS, we may have to punt and let the user define their
   // own namedExports for that package.
 
-  // Retrieve the package versions for all meteor packages used by the application.
-  // .meteor/versions is a simple file in which each line has the syntax
-  //    <pkgname>@<version>
-  // We'll extract them into a Map of versions keyed by package names.
-  const meteorVersionsPath = path.join(config.workingDirectory, '.meteor/versions');
-  if (!fs.existsSync(meteorVersionsPath)) {
-    // If we're even in an application directory, it must be broken. In any case, we can't
-    // find the packages without their versions.
-    return {};
+
+  // The isopack's for 3rd party packages are usually found at
+  //   ~/.meteor/packages/<pkg>/<pkgVersion>
+  // where pkg is the meteorPkg without the 'meteor/' prefix and colons are replaced with
+  //       underlines.
+  let isopackRoot = path.join(os.homedir(), '.meteor/packages', pkg.replace(':', '_'), pkgVersion);
+  let isopackPath = path.join(isopackRoot, 'isopack.json');
+  let isopack = FileUtils.readJsonFile(isopackPath);
+  if (!isopack) {
+    // It is possible that this is a local package as opposed to a 3rd party package. If so, it's
+    // isopack may be in <project-root>/.meteor/isopacks/<pkg>.
+    isopackRoot = path.join(
+      projectRootDir, '.meteor', 'local', 'isopacks', pkg.replace(':', '_'));
+    isopackPath = path.join(isopackRoot, 'isopack.json');
+    isopack = FileUtils.readJsonFile(isopackPath);
+    if (!isopack) {
+      // Can't get anywhere without the main isopack.json.
+      return null;
+    }
   }
-  const pkgVersions = new Map();
-  const pkgVersionPairs: Array<string> = fs.readFileSync(meteorVersionsPath, 'utf8')
-    .match(/^[^@\s]+@[^\s]+$/gm) || [];
-  for (const pkgVersionPair of pkgVersionPairs) {
-    const [pkg, version] = pkgVersionPair.split('@');
-    pkgVersions.set(pkg, version);
+
+  // isopack.json often contains separate sections for every version of the isopacks that
+  // has ever been made available. We're only interested in isopack-2 or isopack-1 at this
+  // time. Prefer the newer isopack-2 specification if available
+  const isopackVer = isopack['isopack-2'] || isopack['isopack-1'];
+  if (!isopackVer || !isopackVer.builds) {
+    // If we didn't find an isopack version we understand or documented builds within it,
+    // we're done.
+    return null;
   }
+  // We can't guess which build the current module is being included in. So, we'll find all
+  // declaredExports from all builds and combine them into one namedExports specification.
+  const declaredExports: Array<string> = [];
+  for (const build of isopackVer.builds) {
+    const buildIsopackPath = path.join(isopackRoot, build.path);
+    const buildIsopack = FileUtils.readJsonFile(buildIsopackPath);
+    if (!buildIsopack || !buildIsopack.declaredExports) {
+      // This build is missing, corrupted, or has no declaredExports. Try the next one.
+      continue;
+    }
+    for (const declaredExport of buildIsopack.declaredExports) {
+      // If this declaredExport is not a "testOnly" export and is not already amongst those we've
+      // gathered, push it into our collection.
+      if (!declaredExport.testOnly && declaredExports.indexOf(declaredExport.name) === -1) {
+        declaredExports.push(declaredExport.name);
+      }
+    }
+
+    // TODO: If the "resources" section of the buildIsopack specifies a mainModule, we need to
+    // attempt to scan it to find exports.
+  }
+  return declaredExports;
+}
+
+function meteorPackageNamedExports({ config }: Object): Object {
+  // This function seeks to extract the named exports from all non-core, 3rd party or local meteor
+  // packages being utilized in the application. The meteorPackageDependencies function identifies
+  // that list of packages.
+
+  // Retrieve the versions of all Meteor packages. Note that local packages aren't absolutely
+  // required to have versions.
+  const pkgVersions = meteorPackageVersions(config.workingDirectory) || new Map();
 
   // Try to identify the exports of all packages identified by meteorPackageDependencies
   const namedExports = {};
-  const meteorPackagesDir = path.join(os.homedir(), '.meteor/packages');
   for (const meteorPkg of meteorPackageDependencies({ config })) {
-    // The isopack's are usually found at
-    //   ~/.meteor/packages/<pkg>/<pkgVersion>
-    // where pkg is the meteorPkg without the 'meteor/' prefix and colons replaced with
-    //       underlines.
-
-    // Strip 'meteor/' off the front of the meteorPkg
     const pkg = meteorPkg.slice(7);
     const pkgVersion = pkgVersions.get(pkg) || '';
-    let isopackRoot = path.join(meteorPackagesDir, pkg.replace(':', '_'), pkgVersion);
-    let isopackPath = path.join(isopackRoot, 'isopack.json');
-    let isopack = FileUtils.readJsonFile(isopackPath);
-    if (!isopack) {
-      // It is possible that this is a local package as opposed to a 3rd party package. If so, it's
-      // isopack may be in <project-root>/.meteor/isopacks/<pkg>.
-      isopackRoot = path.join(
-        config.workingDirectory, '.meteor', 'local', 'isopacks', pkg.replace(':', '_'));
-      isopackPath = path.join(isopackRoot, 'isopack.json');
-      isopack = FileUtils.readJsonFile(isopackPath);
-      if (!isopack) {
-        // Can't get anywhere without the main isopack.json. Go to the next package.
-        continue;
-      }
-    }
+    const extractedExports = extractExportsFromMeteorPackage(
+      config.workingDirectory, pkg, pkgVersion);
 
-    // isopack.json often contains separate sections for every version of the isopacks that
-    // has ever been made available. We're only interested in isopack-2 or isopack-1 at this
-    // time. Prefer the newer isopack-2 specification if available
-    const isopackVer = isopack['isopack-2'] || isopack['isopack-1'];
-    if (!isopackVer || !isopackVer.builds) {
-      // If we didn't find an isopack version we understand or documented builds within it,
-      // we're done. Go to the next package.
-      continue;
-    }
-    // We can't guess which build the current module is being included in. So, we'll find all
-    // declaredExports from all builds and combine them into one namedExports specification.
-    const declaredExports: Array<string> = [];
-    for (const build of isopackVer.builds) {
-      const buildIsopackPath = path.join(isopackRoot, build.path);
-      const buildIsopack = FileUtils.readJsonFile(buildIsopackPath);
-      if (!buildIsopack) {
-        // Something is wrong with this build. Try the next one.
-        continue;
-      }
-      if (!buildIsopack || !buildIsopack.declaredExports) {
-        // Either this build is missing or it has no declaredExports. Try the next one.
-        continue;
-      }
-      for (const declaredExport of buildIsopack.declaredExports) {
-        // If this declaredExport is not a "testOnly" export and is not already amongst those we've
-        // gathered, push it into our collection.
-        if (!declaredExport.testOnly && declaredExports.indexOf(declaredExport.name) === -1) {
-          declaredExports.push(declaredExport.name);
-        }
-      }
-
-      // TODO: If the "resources" section of the buildIsopack specifies a mainModule, we need to
-      // attempt to scan it to find exports.
-    }
     // If we found declared exports, create a namedExports entry for them.
-    if (declaredExports.length) {
-      namedExports[`meteor/${pkg}`] = declaredExports;
+    if (extractedExports && extractedExports.length) {
+      namedExports[meteorPkg] = extractedExports;
     }
   }
   return namedExports;

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -78,9 +78,9 @@ function meteorPackageDependencies(
   // precisely validating them. An assumption is made that the file is basically valid.
   // Thus, they may be extracted with a simple global, multiline match of characters allowed
   // to be in a package name that are at the beginning of a line, possibly following white space.
-  const packages: Array<string> = fs.readFileSync(meteorPackagesPath, 'utf8')
+  const packages: Array<string> = (fs.readFileSync(meteorPackagesPath, 'utf8')
     // extract an array of package names (possibly with preceding whitespace) from the packages file
-    .match(/^\s*[a-z0-9:.\-]+/gm)
+    .match(/^\s*[a-z0-9:.\-]+/gm) || [])
     // add 'meteor/' to the start of each name per Meteor convention
     .map((pkg: string): string => `meteor/${pkg.trimLeft()}`)
     // eliminate those packages that are considered to be core
@@ -191,7 +191,7 @@ function meteorPackageNamedExports({ config }: Object): Object {
   }
   const pkgVersions = new Map();
   const pkgVersionPairs: Array<string> = fs.readFileSync(meteorVersionsPath, 'utf8')
-    .match(/^[^@\s]+@[^\s]+$/gm);
+    .match(/^[^@\s]+@[^\s]+$/gm) || [];
   for (const pkgVersionPair of pkgVersionPairs) {
     const [pkg, version] = pkgVersionPair.split('@');
     pkgVersions.set(pkg, version);
@@ -208,7 +208,7 @@ function meteorPackageNamedExports({ config }: Object): Object {
 
     // Strip 'meteor/' off the front of the meteorPkg
     const pkg = meteorPkg.slice(7);
-    const pkgVersion = pkgVersions.get(pkg);
+    const pkgVersion = pkgVersions.get(pkg) || '';
     let isopackRoot = path.join(meteorPackagesDir, pkg.replace(':', '_'), pkgVersion);
     let isopackPath = path.join(isopackRoot, 'isopack.json');
     if (!fs.existsSync(isopackPath)) {
@@ -244,7 +244,7 @@ function meteorPackageNamedExports({ config }: Object): Object {
         // Something is wrong with this build. Try the next one.
         continue;
       }
-      const buildIsopack: Object = FileUtils.readJsonFile(buildIsopackPath);
+      const buildIsopack = FileUtils.readJsonFile(buildIsopackPath);
       if (!buildIsopack || !buildIsopack.declaredExports) {
         // This build has no declaedExports. Try the next one.
         continue;

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -1,5 +1,10 @@
+// @flow
+
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
+
+import FileUtils from '../FileUtils';
 
 import findPackageDependencies from '../findPackageDependencies';
 
@@ -21,6 +26,24 @@ const coreModules = [
   'meteor/templating',
   'meteor/tracker',
 ];
+
+const coreNamedExports = {
+  'meteor/accounts-base': ['AccountsClient', 'Accounts', 'AccountsServer'],
+  'meteor/blaze': ['Blaze'],
+  'meteor/check': ['check', 'Match'],
+  'meteor/ddp-client': ['DDP'],
+  'meteor/ddp-rate-limiter': ['DDPRateLimiter'],
+  'meteor/ejson': ['EJSON'],
+  'meteor/email': ['Email'],
+  'meteor/http': ['HTTP'],
+  'meteor/meteor': ['Meteor'],
+  'meteor/mongo': ['Mongo'],
+  'meteor/random': ['Random'],
+  'meteor/reactive-var': ['ReactiveVar'],
+  'meteor/session': ['Session'],
+  'meteor/templating': ['Template'],
+  'meteor/tracker': ['Tracker'],
+};
 
 function meteorPackageDependencies(
   { config }: Object
@@ -55,35 +78,196 @@ function meteorPackageDependencies(
   // precisely validating them. An assumption is made that the file is basically valid.
   // Thus, they may be extracted with a simple global, multiline match of characters allowed
   // to be in a package name that are at the beginning of a line, possibly following white space.
-  const packages = fs.readFileSync(meteorPackagesPath, 'utf8')
+  const packages: Array<String> = fs.readFileSync(meteorPackagesPath, 'utf8')
     // extract an array of package names (possibly with preceding whitespace) from the packages file
     .match(/^\s*[a-z0-9:.\-]+/gm)
     // add 'meteor/' to the start of each name per Meteor convention
-    .map((pkg: string) => `meteor/${pkg.trimLeft()}`)
+    .map((pkg: String): String => `meteor/${pkg.trimLeft()}`)
     // eliminate those packages that are considered to be core
     .filter((pkg: string) => coreModules.indexOf(pkg) === -1);
   return packages;
 }
 
+function meteorPackageNamedExports({ config }: Object): Object {
+  // This function seeks to extract the named exports from all non-core, 3rd party meteor packages
+  // being utilized in the application. The meteorPackageDependencies function identifies that
+  // list of packages.
+  //
+  // 3rd party packages are deployed as "isopacks". These can usually be found within the meteor
+  // warehouse directory on the system at ~/.meteor/packages. These isopacks do not exactly
+  // contain the original package source. In particular, they are always missing a "package.js"
+  // file. This is important to us because it is the one that specifies the interface. They do
+  // however contain build products that resulted from that specification.
+  //
+  // Meteor is an isomorphic environment. An isopack contains multiple builds, one for each
+  // targeted platform. Typically, this will include at least a client and a server build.  An
+  // isopack contains an isopack.json file that details which platforms are represented and
+  // leads us to other platform specific isopack.json files that contain the interface details
+  // needed by this routine.
+  //
+  // This routine will find all interfaces from all build platforms and create namedExport
+  // entries for them.
+  //
+  // So, for example, if a project includes version 1.5.3 of package "aldeed:simple-schema", the
+  // isopack for that package will usually be located at
+  //    ~/.meteor/packages/aldeed_simple-schema/1.5.3/
+  // Within that directory, we will find the following important files
+  //
+  //    isopack.json
+  //    os.json
+  //    web.browser.json
+  //    web.cordova.json
+  //
+  // isopack.json will point us to the others which all represent specific platforms.
+  //
+  // There are two ways that meteor packages expose their exported interface, pre-ES6 and post-ES6.
+  //
+  // The pre-ES6 modules method is to call api.exports within the package.js file for each variable
+  // exported. These calls all result in declaredExports entries in the individual platform's json
+  // files. Within aldeed:simple-schema's web.browser.json for example, we find
+  //
+  //  "declaredExports": [
+  //      {
+  //        "name": "SimpleSchema",
+  //        "testOnly": false
+  //      },
+  //      {
+  //        "name": "MongoObject",
+  //        "testOnly": false
+  //      },
+  //      {
+  //        "name": "humanize",
+  //        "testOnly": true
+  //      }
+  //    ],
+  //
+  // From this, we can determine that the namedExports entry should be
+  //
+  //   'aldeed:simple-schema': ['SimpleSchema', 'MongoObject']
+  //
+  // "humanize" was left off because it is testOnly. We may try to get smarter and include that for
+  // some modules in the future.
+  //
+  // Post-ES6 modules, things become a bit more difficult. The package.js file in a post-ES6 world
+  // specifies a mainModule. Each build will have no more than one mainModule and they may be
+  // different. The mainModule's are denoted in the same build json files that we process to find
+  // the pre-ES6 declaredExports. They are in the resources section which looks like
+  //
+  //   "resources": [
+  //       {
+  //         "type": "source",
+  //         "extension": "js",
+  //         "file": "web.browser/client_main.js",
+  //         "length": 752,
+  //         "offset": 0,
+  //         "path": "client_main.js",
+  //         "hash": "cf1eeaf24f21f7755a7cb3fe1e247d56b5e97acf",
+  //         "fileOptions": {
+  //           "mainModule": true
+  //         }
+  //       },
+  //
+  // We are interested only in the one resource that has fileOptions.mainModule = true.
+  //
+  // The exports are defined by the export statements in the build's mainModule file,
+  // "web.browser/client_main.js" in the above example. So, we'll have to parse the file and
+  // identify the exports. If the file uses ES6 module export syntax, we should be able to
+  // achieve this. If its using CommonJS, we may have to punt and let the user define their
+  // own namedExports for that package.
+
+  // Retrieve the package versions for all meteor packages used by the application.
+  // .meteor/versions is a simple file in which each line has the syntax
+  //    <pkgname>@<version>
+  // We'll extract them into a Map of versions keyed by package names.
+  const meteorVersionsPath = path.join(config.workingDirectory, '.meteor/versions');
+  if (!fs.existsSync(meteorVersionsPath)) {
+    // If we're even in an application directory, it must be broken. In any case, we can't
+    // find the packages without their versions.
+    return {};
+  }
+  const pkgVersions = new Map();
+  const pkgVersionPairs: Array<string> = fs.readFileSync(meteorVersionsPath, 'utf8')
+    .match(/^[^@\s]+@[^\s]+$/gm);
+  for (const pkgVersionPair of pkgVersionPairs) {
+    const [pkg: String, version: String] = pkgVersionPair.split('@');
+    pkgVersions.set(pkg, version);
+  }
+
+  // Try to identify the exports of all packages identified by meteorPackageDependencies
+  const namedExports: Object = {};
+  const meteorPackagesDir: String = path.join(os.homedir(), '.meteor/packages');
+  for (const meteorPkg of meteorPackageDependencies({ config })) {
+    // The isopack's are usually found at
+    //   ~/.meteor/packages/<pkg>/<pkgVersion>
+    // where pkg is the meteorPkg without the 'meteor/' prefix and colons replaced with
+    //       underlines.
+
+    // Strip 'meteor/' off the front of the meteorPkg
+    const pkg: String = meteorPkg.slice(7);
+    const pkgVersion: String = pkgVersions.get(pkg);
+    const isopackRoot: String = path.join(meteorPackagesDir, pkg.replace(':', '_'), pkgVersion);
+    const isopackPath: String = path.join(isopackRoot, 'isopack.json');
+    if (!fs.existsSync(isopackPath)) {
+      // Can't get anywhere without the main isopack.json. Go to the next package.
+      continue;
+    }
+    const isopack: Object = FileUtils.readJsonFile(isopackPath);
+    if (!isopack) {
+      // Can't get anywhere without the main isopack.json. Go to the next package.
+      continue;
+    }
+    // isopack.json often contains separate sections for every version of the isopacks that
+    // has ever been made available. We're only interested in isopack-2 or isopack-1 at this
+    // time. Prefer the newer isopack-2 specification if available
+    const isopackVer = isopack['isopack-2'] || isopack['isopack-1'];
+    if (!isopackVer || !isopackVer.builds) {
+      // If we didn't find an isopack version we understand or documented builds within it,
+      // we're done. Go to the next package.
+      continue;
+    }
+    // We can't guess which build the current module is being included in. So, we'll find all
+    // declaredExports from all builds and combine them into one namedExports specification.
+    const declaredExports: Array<String> = [];
+    for (const build of isopackVer.builds) {
+      const buildIsopackPath: String = path.join(isopackRoot, build.path);
+      if (!fs.existsSync(buildIsopackPath)) {
+        // Something is wrong with this build. Try the next one.
+        continue;
+      }
+      const buildIsopack: Object = FileUtils.readJsonFile(buildIsopackPath);
+      if (!buildIsopack || !buildIsopack.declaredExports) {
+        // This build has no declaedExports. Try the next one.
+        continue;
+      }
+      for (const declaredExport of buildIsopack.declaredExports) {
+        // If this declaredExport is not a "testOnly" export and is not already amongst those we've
+        // gathered, push it into our collection.
+        if (!declaredExport.testOnly && !declaredExports.includes(declaredExport.name)) {
+          declaredExports.push(declaredExport.name);
+        }
+      }
+
+      // TODO: If the "resources" section of the buildIsopack specifies a mainModule, we need to
+      // attempt to scan it to find exports.
+    }
+    // If we found declared exports, create a namedExports entry for them.
+    if (declaredExports.length) {
+      namedExports[`meteor/${pkg}`] = declaredExports;
+    }
+  }
+  return namedExports;
+}
+
 export default {
   coreModules,
 
-  namedExports: {
-    'meteor/accounts-base': ['AccountsClient', 'Accounts', 'AccountsServer'],
-    'meteor/blaze': ['Blaze'],
-    'meteor/check': ['check', 'Match'],
-    'meteor/ddp-client': ['DDP'],
-    'meteor/ddp-rate-limiter': ['DDPRateLimiter'],
-    'meteor/ejson': ['EJSON'],
-    'meteor/email': ['Email'],
-    'meteor/http': ['HTTP'],
-    'meteor/meteor': ['Meteor'],
-    'meteor/mongo': ['Mongo'],
-    'meteor/random': ['Random'],
-    'meteor/reactive-var': ['ReactiveVar'],
-    'meteor/session': ['Session'],
-    'meteor/templating': ['Template'],
-    'meteor/tracker': ['Tracker'],
+  namedExports: ({ config }: Object): Object => {
+    const allNamedExports = coreNamedExports;
+    // There are no worries about this overwriting the definitions of core
+    // namedExports. meteorPackageNamedExports skips core packages. Even if
+    // it did not, it would presumably find correct definitions.
+    Object.assign(allNamedExports, meteorPackageNamedExports({ config }));
+    return allNamedExports;
   },
 
   packageDependencies: ({ config }: Object): Array<String> =>

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -270,6 +270,28 @@ function meteorPackageNamedExports({ config }: Object): Object {
 export default {
   coreModules,
 
+  moduleNameFormatter: ({ moduleName, pathToImportedModule }: Object): string => {
+    // If the module being imported is a Meteor package, it will begin with 'meteor/' and should
+    // not be altered.
+    if (moduleName.startsWith('meteor/')) {
+      return moduleName;
+    }
+    // If the module being imported is an npm package, the path to the module will start with
+    // 'node_modules/' and the moduleName should not be altered.
+    // not be altered.
+    if (pathToImportedModule.startsWith('node_modules/')) {
+      return moduleName;
+    }
+    // If the moduleName does not start with a '.', then import-js is trying to reference it via
+    // an absolute path. In this case, Meteor wants it to start with a '/' and will interpret it
+    // as relative to the project directory root.
+    if (!moduleName.startsWith('.')) {
+      return `/${moduleName}`;
+    }
+    // Otherwise, return the moduleName unchanged.
+    return moduleName;
+  },
+
   namedExports: ({ config }: Object): Object => {
     const allNamedExports = coreNamedExports;
     // There are no worries about this overwriting the definitions of core


### PR DESCRIPTION
This implements a "90%" solution to automatically creating namedExports for both 3rd-party and local Meteor packages used by an app.

It works for the majority of the packages used today, primarily those still using "api.exports" calls in the package.js file to define their interface to users.

Packages that have already converted to the new api.mainModule calls and do not also use the old api.exports interface are not yet supported. Processing those packages will require the implementation of a routine to scan a module for ES6 exports.