### PR TITLE
Fix Meteor absolute path references to modules

### DIFF
--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1962,6 +1962,111 @@ foo
         });
       });
 
+      describe('in a meteor environment', () => {
+        beforeEach(() => {
+          configuration.environments = ['meteor'];
+          existingFiles = ['bar/foo.jsx'];
+          text = 'foo';
+          configuration.lookupPaths = ['bar'];
+        });
+
+        describe('with `useRelativePaths=true`', () => {
+          beforeEach(() => {
+            configuration.useRelativePaths = true;
+          });
+
+          describe('when the current file is in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = 'bar/current.js';
+            });
+
+            it('uses a relative import path', () => {
+              expect(subject()).toEqual(`
+import foo from './foo';
+
+foo
+              `.trim());
+            });
+          });
+
+          describe('when the current file is not in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = '/foo/bar/current.js';
+            });
+
+            it('does not use a relative import path', () => {
+              expect(subject()).toEqual(`
+import foo from '/foo';
+
+foo
+              `.trim());
+            });
+          });
+
+          describe('when the current file is an absolute path in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = `${process.cwd()}/bar/test.js`;
+            });
+
+            it('uses a relative import path', () => {
+              expect(subject()).toEqual(`
+import foo from './foo';
+
+foo
+              `.trim());
+            });
+          });
+        });
+
+        describe('with `useRelativePaths=false`', () => {
+          beforeEach(() => {
+            configuration.useRelativePaths = false;
+          });
+
+          describe('when the current file is in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = 'bar/current.js';
+            });
+
+            it('uses an absolute import path', () => {
+              expect(subject()).toEqual(`
+import foo from '/foo';
+
+foo
+              `.trim());
+            });
+          });
+
+          describe('when the current file is not in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = '/foo/bar/current.js';
+            });
+
+            it('does not use a relative import path', () => {
+              expect(subject()).toEqual(`
+import foo from '/foo';
+
+foo
+              `.trim());
+            });
+          });
+
+          describe('when the current file is an absolute path in the same lookupPath', () => {
+            beforeEach(() => {
+              pathToCurrentFile = `${process.cwd()}/bar/test.js`;
+            });
+
+            it('does not use a relative import path', () => {
+              expect(subject()).toEqual(`
+import foo from '/foo';
+
+foo
+              `.trim());
+            });
+          });
+        });
+      });
+
       describe('with `useRelativePaths=true`', () => {
         beforeEach(() => {
           existingFiles = ['bar/foo.jsx'];

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -68,6 +68,28 @@ function meteorPackageDependencies(
 export default {
   coreModules,
 
+  moduleNameFormatter: ({ moduleName, pathToImportedModule }) => {
+    // If the module being imported is a Meteor package, it will begin with 'meteor/' and should
+    // not be altered.
+    if (moduleName.startsWith('meteor/')) {
+      return moduleName;
+    }
+    // If the module being imported is an npm package, the path to the module will start with
+    // 'node_modules/' and the moduleName should not be altered.
+    // not be altered.
+    if (pathToImportedModule.startsWith('node_modules/')) {
+      return moduleName;
+    }
+    // If the moduleName does not start with a '.', then import-js is trying to reference it via
+    // an absolute path. In this case, Meteor wants it to start with a '/' and will interpret it
+    // as relative to the project directory root.
+    if (!moduleName.startsWith('.')) {
+      return `/${moduleName}`;
+    }
+    // Otherwise, return the moduleName unchanged.
+    return moduleName;
+  },
+
   namedExports: {
     'meteor/accounts-base': ['AccountsClient', 'Accounts', 'AccountsServer'],
     'meteor/blaze': ['Blaze'],


### PR DESCRIPTION
As reported in #288, Meteor wants a '/' in front of absolute paths and interprets them relative to the project root directory.

This PR utilizes the new moduleNameFormatter configuration hook to add the slash in front of module names that are using absolute paths.

This is the final piece required to satisfy #288.