### PR TITLE
Configure Travis to push code coverage to CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,11 @@ node_js:
   - "4"
   - "5"
   - "6"
+
+before_script:
+  - npm install -g codeclimate-test-reporter
+
+script: npm run test:cover
+
+after_script:
+  - codeclimate-test-reporter < coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm Version](https://img.shields.io/npm/v/import-js.svg)](https://www.npmjs.com/package/import-js) [![License](https://img.shields.io/npm/l/import-js.svg)](https://www.npmjs.com/package/import-js) [![Build Status](https://travis-ci.org/Galooshi/import-js.svg)](https://travis-ci.org/Galooshi/import-js)
+[![npm Version](https://img.shields.io/npm/v/import-js.svg)](https://www.npmjs.com/package/import-js) [![License](https://img.shields.io/npm/l/import-js.svg)](https://www.npmjs.com/package/import-js) [![Build Status](https://travis-ci.org/Galooshi/import-js.svg)](https://travis-ci.org/Galooshi/import-js) [![Test Coverage](https://codeclimate.com/github/Galooshi/import-js/badges/coverage.svg)](https://codeclimate.com/github/Galooshi/import-js/coverage)
 
 ImportJS is a tool to automatically import dependencies in your JavaScript
 project. Use it along with one of our editor integrations for

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "clean": "rimraf build",
     "flow": "flow",
     "jest": "jest",
+    "jest:cover": "jest --coverage",
     "lint": "eslint .",
     "prepublish": "npm run clean && npm run build",
     "preversion": "npm run clean && npm run build && npm test",
-    "test": "npm run --silent lint && npm run --silent flow && npm run --silent jest"
+    "test": "npm run --silent lint && npm run --silent flow && npm run --silent jest",
+    "test:cover": "npm run --silent lint && npm run --silent flow && npm run --silent jest:cover"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We want this project to be resilient and we believe that code coverage
will help us identify gaps in our testing.

The CodeClimate documentation is a little unclear about how to properly
set this up, so I am trying this out. I believe that I also need to set
the CODECLIMATE_REPO_TOKEN environment variable, which I have added
through the Travis interface to prevent this secret from being checked
into code.

  https://travis-ci.org/Galooshi/import-js/settings

I've manually uploaded current code coverage to CodeClimate and it looks
like we are at 93%.

  https://codeclimate.com/github/Galooshi/import-js/coverage

I've also configured CodeClimate to update Pull Requests with an
integration.

Fixes #169.