### PR TITLE
Configure CodeClimate to run ESLint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,4 @@
 engines:
   eslint:
-    enabled: false
+    enabled: true
+    channel: "eslint-2"


### PR DESCRIPTION
I originally disabled this to help get CodeClimate successfully set up.
Now that we are past this hurdle, let's try enabling this feature.