### PR TITLE
Remove regex from normalizePath

### DIFF
--- a/lib/normalizePath.js
+++ b/lib/normalizePath.js
@@ -1,14 +1,15 @@
-import escapeRegExp from 'lodash.escaperegexp';
-
-
-export default function normalizePath(rawPath: string, workingDirectory): string {
+export default function normalizePath(
+  rawPath: string,
+  workingDirectory: string
+): string {
   if (!rawPath) {
     return './';
   }
-  const workingDirPattern = RegExp(`^${escapeRegExp(workingDirectory)}`);
-  const normalized = rawPath.replace(workingDirPattern, '.');
-  if (normalized.startsWith('.')) {
-    return normalized;
+  if (rawPath.startsWith(workingDirectory)) {
+    return `.${rawPath.slice(workingDirectory.length)}`;
   }
-  return `./${normalized}`;
+  if (rawPath.startsWith('.')) {
+    return rawPath;
+  }
+  return `./${rawPath}`;
 }


### PR DESCRIPTION
I was looking over code coverage reports and I noticed that this file
had 2484 hits per line, where most other files have hits per line more
in the range of 100. So I looked at the code and noticed that we are
unnecessarily using regex here. By swapping it out for some simple
slicing, we make the code more readable, probably faster, and can drop a
dependency.

While I was at it, I noticed that the workingDirectory argument was
missing its flow type annotation, so I added it.