### PR TITLE
Remove stripFromPath, lookupPaths, and useRelativePaths in favor of moduleNameFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ configuration file in the root folder of your project.
 
 The following configuration options can be used.
 
-- [`lookupPaths`](#lookuppaths)
 - [`excludes`](#excludes)
 - [`aliases`](#aliases)
 - [`environments`](#environments)
@@ -123,21 +122,6 @@ The following configuration options can be used.
 - [`moduleNameFormatter`](#modulenameformatter)
 - [`tab`](#tab)
 - [`logLevel`](#loglevel)
-
-### `lookupPaths`
-
-Configure where ImportJS should look to resolve imports. If you are using
-Webpack, these should match the `modulesDirectories` configuration. Example:
-
-```javascript
-lookupPaths: [
-  'app/assets/javascripts',
-  'react-components',
-]
-```
-
-*Tip:* Don't put `node_modules` here. ImportJS will find your Node dependencies
-through your `package.json` file.
 
 ### `excludes`
 
@@ -239,8 +223,7 @@ memoize(() => { foo() });
 
 The key used to describe the named exports should be a valid import path. This
 can be e.g. the name of a package found under `node_modules`, a path to a
-module you created yourself without one of the `lookupPaths` prefixes, or a
-relative import path.
+module you created yourself, or a relative import path.
 
 ### `declarationKeyword`
 
@@ -326,8 +309,7 @@ import Foo from './foo';
 import Bar from '../baz/bar';
 ```
 
-Only imports located in the same `lookupPaths` will be made relative to each
-other. Package dependencies (located in `node_modules`) will not be imported
+Package dependencies (located in `node_modules`) will not be imported
 relatively.
 
 You can disable this by setting it to false:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ The following configuration options can be used.
 - [`groupImports`](#groupimports)
 - [`importDevDependencies`](#importdevdependencies)
 - [`importFunction`](#importfunction)
-- [`stripFromPath`](#stripfrompath)
 - [`stripFileExtensions`](#stripfileextensions)
 - [`useRelativePaths`](#userelativepaths)
 - [`ignorePackagePrefixes`](#ignorepackageprefixes)
@@ -307,17 +306,6 @@ importing](http://wiki.commonjs.org/wiki/Modules/1.1).
 importFunction: 'myCustomRequireFunction'
 ```
 
-### `stripFromPath`
-
-This option is used to trim imports by removing a slice of the path. The main
-rationale for using this option is if you have a custom `importFunction` that
-has different logic than the default `require` and `import from` behavior.
-
-```javascript
-stripFromPath: 'app/assets/',
-importFunction: 'requireFromAppAssets',
-```
-
 ### `stripFileExtensions`
 
 An array that controls what file extensions are stripped out from the resulting
@@ -481,7 +469,6 @@ When using `appliesFrom` only a subset of configurations are supported:
 - `declarationKeyword`
 - `importFunction`
 - `stripFileExtensions`
-- `stripFromPath`
 - `useRelativePaths`
 
 ## Dynamic configuration

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ The following configuration options can be used.
 - [`importDevDependencies`](#importdevdependencies)
 - [`importFunction`](#importfunction)
 - [`stripFileExtensions`](#stripfileextensions)
-- [`useRelativePaths`](#userelativepaths)
 - [`ignorePackagePrefixes`](#ignorepackageprefixes)
 - [`minimumVersion`](#minimumversion)
 - [`maxLineLength`](#maxlinelength)
@@ -299,25 +298,6 @@ an empty array `[]` to avoid stripping out extensions.
 stripFileExtensions: ['.web.js', '.js']
 ```
 
-### `useRelativePaths`
-
-This option is enabled by default. When enabled, imports will be resolved
-relative to the current file being edited.
-
-```javascript
-import Foo from './foo';
-import Bar from '../baz/bar';
-```
-
-Package dependencies (located in `node_modules`) will not be imported
-relatively.
-
-You can disable this by setting it to false:
-
-```javascript
-useRelativePaths: false
-```
-
 ### `ignorePackagePrefixes`
 
 If you have package dependencies specified in `package.json` that are prefixed
@@ -417,7 +397,6 @@ through the `appliesTo` and `appliesFrom` options.
   {
     appliesTo: 'app/**',
     declarationKeyword: 'import',
-    useRelativePaths: true,
   },
   {
     appliesTo: 'app/**',
@@ -428,7 +407,6 @@ through the `appliesTo` and `appliesFrom` options.
     appliesTo: 'app/**',
     declarationKeyword: 'var',
     importFunction: 'mockRequire',
-    useRelativePaths: false,
   },
 ]
 ```
@@ -451,7 +429,6 @@ When using `appliesFrom` only a subset of configurations are supported:
 - `declarationKeyword`
 - `importFunction`
 - `stripFileExtensions`
-- `useRelativePaths`
 
 ## Dynamic configuration
 
@@ -481,23 +458,6 @@ module.exports {
       return 'const';
     }
     return 'import';
-  },
-}
-```
-
-Here's a more elaborate example taking both `pathToImportedModule` and
-`pathToCurrentFile` into account:
-
-```javascript
-module.exports {
-  useRelativePaths({ pathToImportedModule, pathToCurrentFile }) {
-    if (pathToCurrentFile.endsWith('-mock.js')) {
-      return false;
-    }
-    if (pathToImportedModule.endsWith('-test.js')) {
-      return false;
-    }
-    return true;
   },
 }
 ```

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -35,7 +35,6 @@ const DEFAULT_CONFIG = {
   moduleSideEffectImports: (): Array<string> => [],
   stripFileExtensions: ['.js', '.jsx'],
   tab: '  ',
-  useRelativePaths: true,
   packageDependencies: ({ config }: Object): Array<string> =>
     findPackageDependencies(
       config.workingDirectory,
@@ -64,7 +63,6 @@ const RENAMED_CONFIGURATION_OPTIONS = {
   max_line_length: 'maxLineLength',
   minimum_version: 'minimumVersion',
   strip_file_extensions: 'stripFileExtensions',
-  use_relative_paths: 'useRelativePaths',
 };
 
 const KNOWN_CONFIGURATION_OPTIONS = [
@@ -87,7 +85,6 @@ const KNOWN_CONFIGURATION_OPTIONS = [
   'namedExports',
   'stripFileExtensions',
   'tab',
-  'useRelativePaths',
 ];
 
 const ENVIRONMENTS = {
@@ -338,11 +335,15 @@ export default class Configuration {
       hasNamedExports: true,
       variableName,
     });
-    if (this.get('useRelativePaths', { pathToImportedModule: relativeFilePath }) &&
-      !relativeFilePath.startsWith('meteor/') &&
-      !relativeFilePath.startsWith('node_modules')) {
-      jsModule.makeRelativeTo(this.pathToCurrentFile);
+
+    if (
+      relativeFilePath.startsWith('meteor/')
+      || relativeFilePath.startsWith('node_modules/')
+    ) {
+      return jsModule;
     }
+
+    jsModule.makeRelativeTo(this.pathToCurrentFile);
     return jsModule;
   }
 }

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -35,7 +35,6 @@ const DEFAULT_CONFIG = {
   moduleNameFormatter: ({ moduleName }: Object): string => moduleName,
   moduleSideEffectImports: (): Array<string> => [],
   stripFileExtensions: ['.js', '.jsx'],
-  stripFromPath: null,
   tab: '  ',
   useRelativePaths: true,
   packageDependencies: ({ config }: Object): Array<string> =>
@@ -67,7 +66,6 @@ const RENAMED_CONFIGURATION_OPTIONS = {
   max_line_length: 'maxLineLength',
   minimum_version: 'minimumVersion',
   strip_file_extensions: 'stripFileExtensions',
-  strip_from_path: 'stripFromPath',
   use_relative_paths: 'useRelativePaths',
 };
 
@@ -91,7 +89,6 @@ const KNOWN_CONFIGURATION_OPTIONS = [
   'moduleSideEffectImports',
   'namedExports',
   'stripFileExtensions',
-  'stripFromPath',
   'tab',
   'useRelativePaths',
 ];

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -29,7 +29,6 @@ const DEFAULT_CONFIG = {
   importDevDependencies: false,
   importFunction: 'require',
   logLevel: 'info',
-  lookupPaths: ['.'],
   maxLineLength: 80,
   minimumVersion: '0.0.0',
   moduleNameFormatter: ({ moduleName }: Object): string => moduleName,
@@ -62,7 +61,6 @@ const RENAMED_CONFIGURATION_OPTIONS = {
   ignore_package_prefixes: 'ignorePackagePrefixes',
   import_dev_dependencies: 'importDevDependencies',
   import_function: 'importFunction',
-  lookup_paths: 'lookupPaths',
   max_line_length: 'maxLineLength',
   minimum_version: 'minimumVersion',
   strip_file_extensions: 'stripFileExtensions',
@@ -82,7 +80,6 @@ const KNOWN_CONFIGURATION_OPTIONS = [
   'importDevDependencies',
   'importFunction',
   'logLevel',
-  'lookupPaths',
   'maxLineLength',
   'minimumVersion',
   'moduleNameFormatter',
@@ -344,7 +341,6 @@ export default class Configuration {
     if (this.get('useRelativePaths', { pathToImportedModule: relativeFilePath }) &&
       !relativeFilePath.startsWith('meteor/') &&
       !relativeFilePath.startsWith('node_modules')) {
-      jsModule.lookupPath = '.'; // hacky way to force relative paths
       jsModule.makeRelativeTo(this.pathToCurrentFile);
     }
     return jsModule;

--- a/lib/JsModule.js
+++ b/lib/JsModule.js
@@ -7,13 +7,6 @@ import ImportStatement from './ImportStatement';
 import requireResolve from './requireResolve';
 import resolveImportPathAndMain from './resolveImportPathAndMain';
 
-function normalizePath(pathToNormalize: string): string {
-  if (!pathToNormalize) {
-    return '';
-  }
-  return pathToNormalize.replace(/^\.\/?/, '');
-}
-
 // TODO figure out a more holistic solution than stripping node_modules
 function stripNodeModules(path: string): string {
   if (path.startsWith('node_modules/')) {
@@ -60,7 +53,7 @@ export default class JsModule {
     workingDirectory: string
   } = {}): ?JsModule {
     const jsModule = new JsModule();
-    jsModule.filePath = normalizePath(relativeFilePath);
+    jsModule.filePath = relativeFilePath;
 
     const importPathAndMainFile = resolveImportPathAndMain(
       jsModule.filePath, stripFileExtensions, workingDirectory);

--- a/lib/JsModule.js
+++ b/lib/JsModule.js
@@ -36,7 +36,6 @@ export default class JsModule {
    *   the project root.
    * @param {Array} opts.stripFileExtensions a list of file extensions to strip,
    *   e.g. ['.js', '.jsx']
-   * @param {String} opts.stripFromPath
    * @param {String} opts.variableName
    * @param {String} opts.workingDirectory
    * @return {JsModule}
@@ -47,7 +46,6 @@ export default class JsModule {
     makeRelativeTo,
     relativeFilePath,
     stripFileExtensions,
-    stripFromPath,
     variableName,
     workingDirectory = process.cwd(),
   }: {
@@ -56,7 +54,6 @@ export default class JsModule {
     makeRelativeTo?: ?string,
     relativeFilePath: string,
     stripFileExtensions: Array<string>,
-    stripFromPath?: string,
     variableName: string,
     workingDirectory: string
   } = {}): ?JsModule {
@@ -86,8 +83,6 @@ export default class JsModule {
     jsModule.variableName = variableName;
     if (makeRelativeTo) {
       jsModule.makeRelativeTo(makeRelativeTo);
-    } else if (stripFromPath) {
-      jsModule.stripFromPath(stripFromPath);
     }
     return jsModule;
   }
@@ -131,14 +126,6 @@ export default class JsModule {
     }
 
     this.importPath = importPath;
-  }
-
-  stripFromPath(prefix: string) {
-    if (!prefix) {
-      return;
-    }
-    this.importPath = this.importPath.replace(
-      RegExp(`^${escapeRegExp(prefix)}`), '');
   }
 
   displayName(): string {

--- a/lib/JsModule.js
+++ b/lib/JsModule.js
@@ -2,8 +2,6 @@
 
 import path from 'path';
 
-import escapeRegExp from 'lodash.escaperegexp';
-
 import Configuration from './Configuration';
 import ImportStatement from './ImportStatement';
 import requireResolve from './requireResolve';
@@ -16,19 +14,25 @@ function normalizePath(pathToNormalize: string): string {
   return pathToNormalize.replace(/^\.\/?/, '');
 }
 
+// TODO figure out a more holistic solution than stripping node_modules
+function stripNodeModules(path: string): string {
+  if (path.startsWith('node_modules/')) {
+    return path.slice(13);
+  }
+
+  return path;
+}
+
 // Class that represents a js module found in the file system
 export default class JsModule {
   hasNamedExports: ?boolean;
   importPath: string;
-  lookupPath: string;
   filePath: string;
   mainFile: ?string;
   variableName: string;
   workingDirectory: string;
 
   /**
-   * @param {String} opts.lookupPath the lookup path in which this module was
-   *   found
    * @param {Boolean} hasNamedExports
    * @param {String|null} opts.makeRelativeTo a path to a different file which
    *   the resulting import path should be relative to.
@@ -42,7 +46,6 @@ export default class JsModule {
    */
   static construct({
     hasNamedExports,
-    lookupPath,
     makeRelativeTo,
     relativeFilePath,
     stripFileExtensions,
@@ -50,7 +53,6 @@ export default class JsModule {
     workingDirectory = process.cwd(),
   }: {
     hasNamedExports?: boolean,
-    lookupPath: string,
     makeRelativeTo?: ?string,
     relativeFilePath: string,
     stripFileExtensions: Array<string>,
@@ -58,12 +60,11 @@ export default class JsModule {
     workingDirectory: string
   } = {}): ?JsModule {
     const jsModule = new JsModule();
-    jsModule.lookupPath = normalizePath(lookupPath);
     jsModule.filePath = normalizePath(relativeFilePath);
 
     const importPathAndMainFile = resolveImportPathAndMain(
       jsModule.filePath, stripFileExtensions, workingDirectory);
-    let importPath = importPathAndMainFile[0];
+    const importPath = importPathAndMainFile[0];
     const mainFile = importPathAndMainFile[1];
 
     if (!importPath) {
@@ -73,9 +74,6 @@ export default class JsModule {
     if (mainFile) {
       jsModule.filePath = path.normalize(`${importPath}/${mainFile}`);
     }
-
-    importPath = importPath.replace(
-      RegExp(`^${escapeRegExp(jsModule.lookupPath)}\/`), '');
 
     jsModule.importPath = importPath;
     jsModule.mainFile = mainFile;
@@ -102,21 +100,8 @@ export default class JsModule {
   }
 
   makeRelativeTo(makeRelativeToPath: string) {
-    if (this.lookupPath === undefined || this.lookupPath === null) {
-      return;
-    }
-
-    // Ignore if the file to relate to is part of a different lookupPath
-    if (!makeRelativeToPath.startsWith(this.lookupPath)) {
-      return;
-    }
-
-    // Strip out the lookupPath
-    const makeRelativeTo = makeRelativeToPath.replace(
-      RegExp(`^${escapeRegExp(this.lookupPath)}/`), '');
-
     let importPath = path.relative(
-      path.dirname(makeRelativeTo),
+      path.dirname(makeRelativeToPath),
       this.importPath
     );
 
@@ -129,7 +114,8 @@ export default class JsModule {
   }
 
   displayName(): string {
-    const parts = [this.importPath];
+    // TODO figure out a more holistic solution than stripping node_modules
+    const parts = [stripNodeModules(this.importPath)];
     if (this.mainFile) {
       parts.push(` (main: ${this.mainFile})`);
     }
@@ -169,8 +155,10 @@ export default class JsModule {
       defaultImport = this.variableName;
     }
 
-    const pathToImportedModule = this.resolvedFilePath(config.pathToCurrentFile,
-                                                       config.workingDirectory);
+    // TODO figure out a more holistic solution than stripping node_modules
+    const pathToImportedModule = stripNodeModules(this.resolvedFilePath(
+      config.pathToCurrentFile, config.workingDirectory
+    ));
 
     return new ImportStatement({
       declarationKeyword:
@@ -181,7 +169,8 @@ export default class JsModule {
       namedImports,
       path: config.get('moduleNameFormatter', {
         pathToImportedModule,
-        moduleName: this.importPath,
+        // TODO figure out a more holistic solution than stripping node_modules
+        moduleName: stripNodeModules(this.importPath),
       }),
     });
   }

--- a/lib/__mocks__/findMatchingFiles.js
+++ b/lib/__mocks__/findMatchingFiles.js
@@ -2,7 +2,7 @@ import formattedToRegex from '../formattedToRegex';
 
 let existingFiles = [];
 
-export default function findMatchingFiles(lookupPath, variableName) {
+export default function findMatchingFiles(variableName) {
   const formattedVarName = formattedToRegex(variableName);
   const files = existingFiles.filter(file => file.match(
       new RegExp(`(/|^)${formattedVarName}(/index)?(/package)?\.js.*`, 'i')));

--- a/lib/__tests__/Configuration-test.js
+++ b/lib/__tests__/Configuration-test.js
@@ -419,26 +419,21 @@ describe('Configuration', () => {
 
   describe('#get moduleSideEffectImports', () => {
     describe('in meteor environment', () => {
-      describe('with no side-effect imports for a component', () => {
-        beforeEach(() => {
-          FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
-            useRelativePaths: true,
-            environments: ['meteor'],
-          });
+      beforeEach(() => {
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+          environments: ['meteor'],
         });
+      });
 
+      describe('with no side-effect imports for a component', () => {
         it('finds no side-effect imports for components', () => {
           const configuration = new Configuration('./foo/component.js');
           expect(configuration.get('moduleSideEffectImports').sort()).toEqual([]);
         });
       });
 
-      describe('with useRelativePaths true', () => {
+      describe('with side-effect imports for a component', () => {
         beforeEach(() => {
-          FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
-            useRelativePaths: true,
-            environments: ['meteor'],
-          });
           fs.__setFile(path.join(process.cwd(), 'foo', 'component.css'),
             '',
             { isDirectory: () => false }
@@ -456,6 +451,7 @@ describe('Configuration', () => {
             './component.html',
           ]);
         });
+
         it('finds side-effect imports for components related to jsx modules', () => {
           const configuration = new Configuration('./foo/component.jsx');
           expect(configuration.get('moduleSideEffectImports').sort()).toEqual([
@@ -463,34 +459,10 @@ describe('Configuration', () => {
             './component.html',
           ]);
         });
+
         it('returns no side-effect imports for components related to unknown module types', () => {
           const configuration = new Configuration('./foo/component.unk');
           expect(configuration.get('moduleSideEffectImports').sort()).toEqual([]);
-        });
-      });
-
-      describe('with useRelativePaths false', () => {
-        beforeEach(() => {
-          FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
-            useRelativePaths: false,
-            environments: ['meteor'],
-          });
-          fs.__setFile(path.join(process.cwd(), 'foo', 'component.css'),
-            '',
-            { isDirectory: () => false }
-          );
-          fs.__setFile(path.join(process.cwd(), 'foo', 'component.html'),
-            '',
-            { isDirectory: () => false }
-          );
-        });
-
-        it('finds side-effect imports for components and gives them absolute paths', () => {
-          const configuration = new Configuration('./foo/component.js');
-          expect(configuration.get('moduleSideEffectImports').sort()).toEqual([
-            '/foo/component.css',
-            '/foo/component.html',
-          ]);
         });
       });
     });

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1906,111 +1906,6 @@ foo
           configuration.lookupPaths = ['bar'];
         });
 
-        describe('with `useRelativePaths=true`', () => {
-          beforeEach(() => {
-            configuration.useRelativePaths = true;
-          });
-
-          describe('when the current file is in the same lookupPath', () => {
-            beforeEach(() => {
-              pathToCurrentFile = 'bar/current.js';
-            });
-
-            it('uses a relative import path', () => {
-              expect(subject()).toEqual(`
-import foo from './foo';
-
-foo
-              `.trim());
-            });
-          });
-
-          describe('when the current file is not in the same lookupPath', () => {
-            beforeEach(() => {
-              pathToCurrentFile = '/foo/bar/current.js';
-            });
-
-            it('does not use a relative import path', () => {
-              expect(subject()).toEqual(`
-import foo from '/foo';
-
-foo
-              `.trim());
-            });
-          });
-
-          describe('when the current file is an absolute path in the same lookupPath', () => {
-            beforeEach(() => {
-              pathToCurrentFile = `${process.cwd()}/bar/test.js`;
-            });
-
-            it('uses a relative import path', () => {
-              expect(subject()).toEqual(`
-import foo from './foo';
-
-foo
-              `.trim());
-            });
-          });
-        });
-
-        describe('with `useRelativePaths=false`', () => {
-          beforeEach(() => {
-            configuration.useRelativePaths = false;
-          });
-
-          describe('when the current file is in the same lookupPath', () => {
-            beforeEach(() => {
-              pathToCurrentFile = 'bar/current.js';
-            });
-
-            it('uses an absolute import path', () => {
-              expect(subject()).toEqual(`
-import foo from '/foo';
-
-foo
-              `.trim());
-            });
-          });
-
-          describe('when the current file is not in the same lookupPath', () => {
-            beforeEach(() => {
-              pathToCurrentFile = '/foo/bar/current.js';
-            });
-
-            it('does not use a relative import path', () => {
-              expect(subject()).toEqual(`
-import foo from '/foo';
-
-foo
-              `.trim());
-            });
-          });
-
-          describe('when the current file is an absolute path in the same lookupPath', () => {
-            beforeEach(() => {
-              pathToCurrentFile = `${process.cwd()}/bar/test.js`;
-            });
-
-            it('does not use a relative import path', () => {
-              expect(subject()).toEqual(`
-import foo from '/foo';
-
-foo
-              `.trim());
-            });
-          });
-        });
-      });
-
-      describe('with `useRelativePaths=true`', () => {
-        beforeEach(() => {
-          existingFiles = ['bar/foo.jsx'];
-          text = 'foo';
-          configuration.useRelativePaths = true;
-          configuration.lookupPaths = ['bar'];
-        });
-
         describe('when the current file is in the same lookupPath', () => {
           beforeEach(() => {
             pathToCurrentFile = 'bar/current.js';
@@ -2032,7 +1927,7 @@ foo
 
           it('does not use a relative import path', () => {
             expect(subject()).toEqual(`
-import foo from 'foo';
+import foo from '/foo';
 
 foo
             `.trim());
@@ -2051,6 +1946,57 @@ import foo from './foo';
 foo
             `.trim());
           });
+        });
+      });
+
+      describe('when the current file is in the same lookupPath', () => {
+        beforeEach(() => {
+          existingFiles = ['bar/foo.jsx'];
+          text = 'foo';
+          configuration.lookupPaths = ['bar'];
+          pathToCurrentFile = 'bar/current.js';
+        });
+
+        it('uses a relative import path', () => {
+          expect(subject()).toEqual(`
+import foo from './foo';
+
+foo
+          `.trim());
+        });
+      });
+
+      describe('when the current file is not in the same lookupPath', () => {
+        beforeEach(() => {
+          existingFiles = ['bar/foo.jsx'];
+          text = 'foo';
+          configuration.lookupPaths = ['bar'];
+          pathToCurrentFile = '/foo/bar/current.js';
+        });
+
+        it('does not use a relative import path', () => {
+          expect(subject()).toEqual(`
+import foo from 'foo';
+
+foo
+          `.trim());
+        });
+      });
+
+      describe('when the current file is an absolute path in the same lookupPath', () => {
+        beforeEach(() => {
+          existingFiles = ['bar/foo.jsx'];
+          text = 'foo';
+          configuration.lookupPaths = ['bar'];
+          pathToCurrentFile = `${process.cwd()}/bar/test.js`;
+        });
+
+        it('uses a relative import path', () => {
+          expect(subject()).toEqual(`
+import foo from './foo';
+
+foo
+          `.trim());
         });
       });
 
@@ -2089,7 +2035,6 @@ goo
               appliesFrom: 'bar/**/*',
               declarationKeyword: 'var',
               importFunction: 'quack',
-              useRelativePaths: false,
               stripFileExtensions: [],
             });
           });
@@ -2097,7 +2042,7 @@ goo
           describe('that matches the path of the file being imported', () => {
             it('uses local config', () => {
               expect(subject()).toEqual(`
-var goo = quack('bar/goo.jsx');
+var goo = quack('../bar/goo.jsx');
 
 goo
               `.trim());
@@ -2130,7 +2075,6 @@ goo
               },
               appliesFrom: 'bar/**/*',
               declarationKeyword: 'const',
-              useRelativePaths: false,
             });
           });
 
@@ -2894,48 +2838,16 @@ import baz from '../baz';
 bar
         `.trim();
       });
-
-      describe('and we are turning relative paths off', () => {
-        beforeEach(() => {
-          configuration.useRelativePaths = false;
-        });
-
-        it('sorts, groups, and changes to absolute paths', () => {
-          expect(subject()).toEqual(`
-import bar, { foo } from 'bar';
-
-import baz from 'baz';
-
-bar
-          `.trim());
-        });
-      });
     });
 
     describe('when imports use normal paths', () => {
       beforeEach(() => {
         text = `
 import bar, { foo } from 'bar';
-import baz from 'baz';
-
-bar
-        `.trim();
-      });
-
-      describe('and we are turning relative paths on', () => {
-        beforeEach(() => {
-          configuration.useRelativePaths = true;
-        });
-
-        it('sorts, groups, and changes to relative paths', () => {
-          expect(subject()).toEqual(`
-import bar, { foo } from 'bar';
-
 import baz from '../baz';
 
 bar
-          `.trim());
-        });
+        `.trim();
       });
     });
 

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1903,101 +1903,49 @@ foo
           configuration.environments = ['meteor'];
           existingFiles = ['bar/foo.jsx'];
           text = 'foo';
-          configuration.lookupPaths = ['bar'];
         });
 
-        describe('when the current file is in the same lookupPath', () => {
-          beforeEach(() => {
-            pathToCurrentFile = 'bar/current.js';
-          });
-
-          it('uses a relative import path', () => {
-            expect(subject()).toEqual(`
-import foo from './foo';
-
-foo
-            `.trim());
-          });
-        });
-
-        describe('when the current file is not in the same lookupPath', () => {
-          beforeEach(() => {
-            pathToCurrentFile = '/foo/bar/current.js';
-          });
-
-          it('does not use a relative import path', () => {
-            expect(subject()).toEqual(`
-import foo from '/foo';
-
-foo
-            `.trim());
-          });
-        });
-
-        describe('when the current file is an absolute path in the same lookupPath', () => {
-          beforeEach(() => {
-            pathToCurrentFile = `${process.cwd()}/bar/test.js`;
-          });
-
-          it('uses a relative import path', () => {
-            expect(subject()).toEqual(`
-import foo from './foo';
-
-foo
-            `.trim());
-          });
-        });
-      });
-
-      describe('when the current file is in the same lookupPath', () => {
-        beforeEach(() => {
-          existingFiles = ['bar/foo.jsx'];
-          text = 'foo';
-          configuration.lookupPaths = ['bar'];
+        it('uses a relative import path', () => {
           pathToCurrentFile = 'bar/current.js';
-        });
-
-        it('uses a relative import path', () => {
           expect(subject()).toEqual(`
 import foo from './foo';
 
 foo
           `.trim());
         });
-      });
 
-      describe('when the current file is not in the same lookupPath', () => {
-        beforeEach(() => {
-          existingFiles = ['bar/foo.jsx'];
-          text = 'foo';
-          configuration.lookupPaths = ['bar'];
-          pathToCurrentFile = '/foo/bar/current.js';
-        });
-
-        it('does not use a relative import path', () => {
-          expect(subject()).toEqual(`
-import foo from 'foo';
-
-foo
-          `.trim());
-        });
-      });
-
-      describe('when the current file is an absolute path in the same lookupPath', () => {
-        beforeEach(() => {
-          existingFiles = ['bar/foo.jsx'];
-          text = 'foo';
-          configuration.lookupPaths = ['bar'];
+        it('uses a relative import path when the current file is an absolute path', () => {
           pathToCurrentFile = `${process.cwd()}/bar/test.js`;
-        });
-
-        it('uses a relative import path', () => {
           expect(subject()).toEqual(`
 import foo from './foo';
 
 foo
           `.trim());
         });
+      });
+
+      it('uses a relative import path', () => {
+        existingFiles = ['bar/foo.jsx'];
+        text = 'foo';
+        pathToCurrentFile = 'bar/current.js';
+
+        expect(subject()).toEqual(`
+import foo from './foo';
+
+foo
+        `.trim());
+      });
+
+      it('uses a relative import path when the current file is an absolute path', () => {
+        existingFiles = ['bar/foo.jsx'];
+        text = 'foo';
+        pathToCurrentFile = `${process.cwd()}/bar/test.js`;
+
+        expect(subject()).toEqual(`
+import foo from './foo';
+
+foo
+        `.trim());
       });
 
       describe('with local configuration defined in the main config file', () => {

--- a/lib/__tests__/JsModule-test.js
+++ b/lib/__tests__/JsModule-test.js
@@ -13,55 +13,37 @@ describe('JsModule', () => {
     requireResolve.__reset();
   });
 
-  it('does not modify lookupPath when it is .', () => {
-    const lookupPath = '.';
-    JsModule.construct({ lookupPath });
-    expect(lookupPath).toEqual('.');
-  });
-
   it('does not modify relativeFilePath when it is .', () => {
     const relativeFilePath = '.';
     JsModule.construct({ relativeFilePath });
     expect(relativeFilePath).toEqual('.');
   });
 
-  it('strips out the lookup path from relativeFilePath', () => {
-    const jsModule = JsModule.construct({
-      lookupPath: 'app',
-      relativeFilePath: 'app/lib/foo.js',
-    });
-
-    expect(jsModule.importPath).toEqual('lib/foo.js');
-  });
-
   it('strips file extensions that are configured to be stripped', () => {
     const jsModule = JsModule.construct({
-      lookupPath: 'app',
       relativeFilePath: 'app/lib/foo.js',
       stripFileExtensions: ['.js', '.jsx'],
     });
 
-    expect(jsModule.importPath).toEqual('lib/foo');
+    expect(jsModule.importPath).toEqual('app/lib/foo');
   });
 
   it('strips double extensions', () => {
     const jsModule = JsModule.construct({
-      lookupPath: 'app',
       relativeFilePath: 'app/lib/foo.web.js',
       stripFileExtensions: ['.web.js'],
     });
 
-    expect(jsModule.importPath).toEqual('lib/foo');
+    expect(jsModule.importPath).toEqual('app/lib/foo');
   });
 
   it('does not strip parts of double extensions', () => {
     const jsModule = JsModule.construct({
-      lookupPath: 'app',
       relativeFilePath: 'app/lib/foo.js',
       stripFileExtensions: ['.web.js'],
     });
 
-    expect(jsModule.importPath).toEqual('lib/foo.js');
+    expect(jsModule.importPath).toEqual('app/lib/foo.js');
   });
 
   it('creates a valid JsModule when index.js is part of the name', () => {
@@ -73,47 +55,8 @@ describe('JsModule', () => {
     expect(jsModule.displayName()).toEqual('lib/index.js/foo.js');
   });
 
-  it('produces a correct path when lookupPath is the current directory', () => {
-    const jsModule = JsModule.construct({
-      lookupPath: '.',
-      relativeFilePath: './app/lib/foo.js',
-    });
-
-    expect(jsModule.importPath).toEqual('app/lib/foo.js');
-  });
-
-  it('produces a correct path when lookupPath starts with a dot', () => {
-    const jsModule = JsModule.construct({
-      lookupPath: './app',
-      relativeFilePath: './app/lib/foo.js',
-    });
-
-    expect(jsModule.importPath).toEqual('lib/foo.js');
-  });
-
   it('produces a correct path with a relative file in the same directory', () => {
     const jsModule = JsModule.construct({
-      lookupPath: 'app',
-      makeRelativeTo: 'app/lib/bar.js',
-      relativeFilePath: 'app/lib/foo.js',
-    });
-
-    expect(jsModule.importPath).toEqual('./foo.js');
-  });
-
-  it('produces a correct same-directory relative path when lookupPath starts with a dot', () => {
-    const jsModule = JsModule.construct({
-      lookupPath: './app',
-      makeRelativeTo: 'app/lib/bar.js',
-      relativeFilePath: 'app/lib/foo.js',
-    });
-
-    expect(jsModule.importPath).toEqual('./foo.js');
-  });
-
-  it('produces a correct same-directory relative path when lookupPath is current directory', () => {
-    const jsModule = JsModule.construct({
-      lookupPath: '.',
       makeRelativeTo: 'app/lib/bar.js',
       relativeFilePath: 'app/lib/foo.js',
     });
@@ -123,7 +66,6 @@ describe('JsModule', () => {
 
   it('produces a correct relative path when other file is in a parent directory', () => {
     const jsModule = JsModule.construct({
-      lookupPath: 'app',
       makeRelativeTo: 'app/bar.js',
       relativeFilePath: 'app/lib/foo.js',
     });
@@ -133,7 +75,6 @@ describe('JsModule', () => {
 
   it('produces a correct relative path when other file is in a sibling directory', () => {
     const jsModule = JsModule.construct({
-      lookupPath: 'app',
       makeRelativeTo: 'app/foo/bar.js',
       relativeFilePath: 'app/lib/foo.js',
     });
@@ -143,22 +84,11 @@ describe('JsModule', () => {
 
   it('has correct path when other file is in a child of a sibling directory', () => {
     const jsModule = JsModule.construct({
-      lookupPath: 'app',
       makeRelativeTo: 'app/foo/gas/bar.js',
       relativeFilePath: 'app/lib/foo.js',
     });
 
     expect(jsModule.importPath).toEqual('../../lib/foo.js');
-  });
-
-  it('does not create a relative path when other file is in a different lookupPath', () => {
-    const jsModule = JsModule.construct({
-      lookupPath: 'app',
-      makeRelativeTo: 'spec/foo/gas/bar.js',
-      relativeFilePath: 'app/lib/foo.js',
-    });
-
-    expect(jsModule.importPath).toEqual('lib/foo.js');
   });
 
   describe('when relative file path has /package.json and a relative main', () => {

--- a/lib/__tests__/JsModule-test.js
+++ b/lib/__tests__/JsModule-test.js
@@ -64,37 +64,6 @@ describe('JsModule', () => {
     expect(jsModule.importPath).toEqual('lib/foo.js');
   });
 
-  it('strips stripFromPath from the beginning of the path', () => {
-    const jsModule = JsModule.construct({
-      lookupPath: 'app',
-      stripFromPath: 'lib',
-      relativeFilePath: 'app/lib/foo.js',
-    });
-
-    expect(jsModule.importPath).toEqual('/foo.js');
-  });
-
-  it('does not strip anything when stripFromPath is not at the beginning', () => {
-    const jsModule = JsModule.construct({
-      lookupPath: 'app',
-      stripFromPath: 'foo',
-      relativeFilePath: 'app/lib/foo.js',
-    });
-
-    expect(jsModule.importPath).toEqual('lib/foo.js');
-  });
-
-  it('prefers makeRelativeTo over stripFromPath', () => {
-    const jsModule = JsModule.construct({
-      lookupPath: 'app',
-      stripFromPath: 'lib',
-      relativeFilePath: 'app/lib/foo.js',
-      makeRelativeTo: 'app/assets/bar.js',
-    });
-
-    expect(jsModule.importPath).toEqual('../lib/foo.js');
-  });
-
   it('creates a valid JsModule when index.js is part of the name', () => {
     const jsModule = JsModule.construct({
       relativeFilePath: 'lib/index.js/foo.js',

--- a/lib/__tests__/findMatchingFiles-test.js
+++ b/lib/__tests__/findMatchingFiles-test.js
@@ -15,7 +15,6 @@ import findMatchingFiles from '../findMatchingFiles';
     let subject;
     let word;
     let existingFiles;
-    let lookupPath;
     let originalPlatform;
     let workingDirectory;
 
@@ -41,7 +40,6 @@ import findMatchingFiles from '../findMatchingFiles';
     if (finder === 'watchman') {
       beforeEach(() => {
         word = 'foo';
-        lookupPath = '.';
 
         subject = () => {
           const watchmanFileCache = WatchmanFileCache.getForWorkingDirectory(
@@ -49,7 +47,7 @@ import findMatchingFiles from '../findMatchingFiles';
           spyOn(watchmanFileCache, 'getFiles').and.returnValue(
             new Set(existingFiles.map((file) => `./${file}`)));
           spyOn(watchmanFileCache, 'isEnabled').and.returnValue(true);
-          return findMatchingFiles(lookupPath, word, workingDirectory);
+          return findMatchingFiles(word, workingDirectory);
         };
       });
     } else {
@@ -57,7 +55,6 @@ import findMatchingFiles from '../findMatchingFiles';
         fs.mkdirSync(tmpDir);
         word = 'foo';
         existingFiles = [];
-        lookupPath = '.';
 
         subject = () => {
           existingFiles.forEach((file) => {
@@ -66,7 +63,7 @@ import findMatchingFiles from '../findMatchingFiles';
             fs.closeSync(fs.openSync(fullPath, 'w')); // create empty file
           });
 
-          return findMatchingFiles(lookupPath, word, workingDirectory);
+          return findMatchingFiles(word, workingDirectory);
         };
       });
     }
@@ -87,16 +84,6 @@ import findMatchingFiles from '../findMatchingFiles';
           expect(files).toEqual([]);
           done();
         });
-      });
-    });
-
-    describe('when the lookup path is empty', () => {
-      beforeEach(() => {
-        lookupPath = '';
-      });
-
-      it('throws an error', () => {
-        expect(subject).toThrowError(/empty/);
       });
     });
 

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -359,13 +359,7 @@ export default {
     ['.html', '.css'].forEach((ext: string) => {
       const moduleSpecifier = `${basePath}${ext}`;
       if (fs.existsSync(path.join(config.workingDirectory, moduleSpecifier))) {
-        if (config.get('useRelativePaths')) {
-          moduleSpecifiers.push('.'.concat(path.sep, path.basename(moduleSpecifier)));
-        } else {
-          // Strip the leading '.' off of the moduleSpecifier to turn it into a
-          // Meteor compliant absolute path.
-          moduleSpecifiers.push(moduleSpecifier.slice(1));
-        }
+        moduleSpecifiers.push('.'.concat(path.sep, path.basename(moduleSpecifier)));
       }
     });
 

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -359,7 +359,7 @@ export default {
     ['.html', '.css'].forEach((ext: string) => {
       const moduleSpecifier = `${basePath}${ext}`;
       if (fs.existsSync(path.join(config.workingDirectory, moduleSpecifier))) {
-        moduleSpecifiers.push('.'.concat(path.sep, path.basename(moduleSpecifier)));
+        moduleSpecifiers.push(`.${path.sep}${path.basename(moduleSpecifier)}`);
       }
     });
 

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -82,7 +82,6 @@ function findImportsFromLocalFiles(
             makeRelativeTo:
               config.get('useRelativePaths', { pathToImportedModule: f }) &&
               pathToCurrentFile,
-            stripFromPath: config.get('stripFromPath', { pathToImportedModule: f }),
             variableName,
             workingDirectory: config.workingDirectory,
           });

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -69,9 +69,7 @@ function findImportsFromLocalFiles(
           relativeFilePath: f,
           stripFileExtensions:
             config.get('stripFileExtensions', { pathToImportedModule: f }),
-          makeRelativeTo:
-            config.get('useRelativePaths', { pathToImportedModule: f }) &&
-            pathToCurrentFile,
+          makeRelativeTo: pathToCurrentFile,
           variableName,
           workingDirectory: config.workingDirectory,
         });

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -39,7 +39,6 @@ function findImportsFromPackageJson(
     .filter((dep: string): boolean => depRegex.test(dep))
     .map((dep: string): ?JsModule => (
       JsModule.construct({
-        lookupPath: 'node_modules',
         relativeFilePath: `node_modules/${dep}/package.json`,
         stripFileExtensions: [],
         variableName,
@@ -55,41 +54,31 @@ function findImportsFromLocalFiles(
   pathToCurrentFile: string
 ): Promise<Array<JsModule>> {
   return new Promise((resolve: Function, reject: Function) => {
-    const lookupPaths = config.get('lookupPaths');
-    const promises = lookupPaths.map((lookupPath: string): Promise<Array<string>> =>
-        findMatchingFiles(lookupPath, variableName, config.workingDirectory));
-
-    Promise.all(promises).then((results: Array<Array<string>>) => {
+    findMatchingFiles(variableName, config.workingDirectory)
+    .then((files: Array<string>) => {
       const matchedModules = [];
       const excludes = config.get('excludes');
-      results.forEach((files: Array<string>, index: number) => {
-        // Grab the lookup path originally associated with the promise. Because
-        // Promise.all maintains the order of promises, we can use the index
-        // here.
-        const lookupPath = lookupPaths[index];
-        files.forEach((f: string) => {
-          const isExcluded = excludes
-            .some((globPattern: string): boolean => minimatch(f, globPattern));
-          if (isExcluded) {
-            return;
-          }
+      files.forEach((f: string) => {
+        const isExcluded = excludes
+          .some((globPattern: string): boolean => minimatch(f, globPattern));
+        if (isExcluded) {
+          return;
+        }
 
-          const module = JsModule.construct({
-            lookupPath,
-            relativeFilePath: f,
-            stripFileExtensions:
-              config.get('stripFileExtensions', { pathToImportedModule: f }),
-            makeRelativeTo:
-              config.get('useRelativePaths', { pathToImportedModule: f }) &&
-              pathToCurrentFile,
-            variableName,
-            workingDirectory: config.workingDirectory,
-          });
-
-          if (module) {
-            matchedModules.push(module);
-          }
+        const module = JsModule.construct({
+          relativeFilePath: f,
+          stripFileExtensions:
+            config.get('stripFileExtensions', { pathToImportedModule: f }),
+          makeRelativeTo:
+            config.get('useRelativePaths', { pathToImportedModule: f }) &&
+            pathToCurrentFile,
+          variableName,
+          workingDirectory: config.workingDirectory,
         });
+
+        if (module) {
+          matchedModules.push(module);
+        }
       });
       resolve(matchedModules);
     }).catch((error: Object) => {

--- a/lib/findMatchingFiles.js
+++ b/lib/findMatchingFiles.js
@@ -6,15 +6,13 @@ import glob from 'glob';
 
 import WatchmanFileCache from './WatchmanFileCache';
 import formattedToRegex from './formattedToRegex';
-import normalizePath from './normalizePath';
 
 function findMatchingFilesWithFind(
-  lookupPath: string,
   validFilesPattern: string,
   workingDirectory: string
 ): Promise<Array<string>> {
   const findCommand = [
-    `find ${lookupPath}`,
+    'find .',
     '-name "**.js*"',
     '-not -path "./node_modules/*"',
   ].join(' ');
@@ -39,13 +37,12 @@ function findMatchingFilesWithFind(
 }
 
 function findMatchingFilesWithNode(
-  lookupPath: string,
   validFilesPattern: string,
   workingDirectory: string
 ): Promise<Array<string>> {
   const validFilesRegex = new RegExp(validFilesPattern, 'i');
   return new Promise((resolve: Function, reject: Function) => {
-    glob(`${lookupPath}/**/*.js*`, {
+    glob('./**/*.js*', {
       ignore: './node_modules/**',
       cwd: workingDirectory,
     }, (err: Object, result: Array<string>) => {
@@ -60,20 +57,15 @@ function findMatchingFilesWithNode(
 }
 
 function findMatchingFilesWithWatchman(
-  lookupPath: string,
   validFilesPattern: string,
   workingDirectory: string
 ): Promise<Array<string>> {
   const validFilesRegex = new RegExp(validFilesPattern, 'i');
-  const normalizedLookupPath = normalizePath(lookupPath, workingDirectory);
   return new Promise((resolve: Function) => {
     const matches = [];
     // `getFiles()` returns a Set, so we can't use `filter` here.
     WatchmanFileCache.getForWorkingDirectory(workingDirectory).getFiles()
       .forEach((filePath: string) => {
-        if (!filePath.startsWith(normalizedLookupPath)) {
-          return;
-        }
         if (validFilesRegex.test(filePath)) {
           matches.push(filePath);
         }
@@ -86,28 +78,18 @@ function findMatchingFilesWithWatchman(
  * Finds files from the local file system matching the variable name.
  */
 export default function findMatchingFiles(
-  lookupPath: string,
   variableName: string,
   workingDirectory: string = process.cwd()
 ): Promise<Array<string>> {
-  if (lookupPath === '') {
-    // If lookupPath is an empty string, the `find` command will not work
-    // as desired so we bail early.
-    throw new Error(`lookup path cannot be empty (${lookupPath})`);
-  }
-
   const formattedVarName = formattedToRegex(variableName);
   const validFilesPattern = `(/|^)${formattedVarName}(/index)?(/package)?\\.js.*`;
 
   if (WatchmanFileCache.getForWorkingDirectory(workingDirectory).isEnabled()) {
-    return findMatchingFilesWithWatchman(
-      lookupPath, validFilesPattern, workingDirectory);
+    return findMatchingFilesWithWatchman(validFilesPattern, workingDirectory);
   }
   if (/^win/.test(process.platform) ||
       process.env.IMPORT_JS_USE_NODE_FINDER) {
-    return findMatchingFilesWithNode(
-      lookupPath, validFilesPattern, workingDirectory);
+    return findMatchingFilesWithNode(validFilesPattern, workingDirectory);
   }
-  return findMatchingFilesWithFind(
-    lookupPath, validFilesPattern, workingDirectory);
+  return findMatchingFilesWithFind(validFilesPattern, workingDirectory);
 }


### PR DESCRIPTION
The `stripFromPath` option is mutating paths in between configuration
calls. This is no good because it means that configuration cannot rely
on paths being consistent when performing checks (e.g. when trying to
determine if something is a test file).

I originally started working to move this so it doesn't mutate the path
in JsModule at all. After I had that working, I realized that we
recently added a new configuration option that could be used to solve
the same use-case as this one: `moduleNameFormatter`. Since this is
currently causing bugs and since we already have a replacement ready, I
decided to simply remove this. This is a breaking change.

After I removed this, I realized that we have a few more options that
mutate the paths between configuration calls (`lookupPaths` and 
`useRelativePaths`), and which could be replaced by
`moduleNameFormatter` so I removed those as well.

If we decide to go forward with this, we should probably provide some
good examples of how to configure things to produce the desired effects.

We should add some tests that verify that paths don't change between
configuration checks, regardless of what they return.

We might also want to consider removing `stripFileExtensions` in favor of
a good default `moduleNameFormatter` function that does the same type
of thing.

Addresses #327