### PR TITLE
Add `importjsd logpath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,8 +429,8 @@ logLevel: 'debug'
 ```
 
 The logfile is written to "importjs.log" in your operating system's default
-directory for temporary files. `importjsd` reports the log location when it
-starts.
+directory for temporary files. You can get the path to the log file by running
+`importjsd logpath`.
 
 ## Local configuration (*deprecated*)
 

--- a/bin/importjsd.js
+++ b/bin/importjsd.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../build/daemon.js')();
+require('../build/daemon.js')(process.argv);

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -23,9 +23,13 @@ const commandsToFunctionNames = {
   add: 'addImports',
 };
 
-commander.option('--parent-pid <n>', parseInt).parse(process.argv);
+commander.option('--parent-pid <n>', parseInt);
 
-export default function daemon() {
+commander.command('logpath').action(() => {
+  process.stdout.write(`${pathToLogFile}\n`);
+});
+
+function start() {
   // The `importjsd` here is mostly a dummy file because config relies on a
   // `pathToCurrentFile`. Normally, this is the javascript file you are editing.
   const config = new Configuration('importjsd');
@@ -99,4 +103,12 @@ export default function daemon() {
       process.stdout.write(`${jsonResponse}\n`);
     });
   });
+}
+
+export default function daemon(argv: Array<string>) {
+  commander.parse(argv);
+
+  if (!argv.slice(2).length) {
+    start();
+  }
 }


### PR DESCRIPTION
When debugging, I need to be able to find the path to the log file. I
think it will be nice to add a command to output this for convenience.