### PR TITLE
Deprecate .importjs.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,8 @@ the cursor on a variable and hit `<leader>g` (Vim), `(M-x) import-js-goto`
 
 ## Configuration
 
-ImportJS can be configured through a JSON file (`.importjs.json`) or a
-JavaScript file (`.importjs.js`). Save the configuration file in the root
-folder of your project.
+ImportJS is configured through a JavaScript file (`.importjs.js`). Save the
+configuration file in the root folder of your project.
 
 The following configuration options can be used.
 
@@ -366,7 +365,7 @@ example, a variable named `validator` would match a package named
 ### `minimumVersion`
 
 Setting `minimumVersion` will warn people who are running a version of
-ImportJS that is older than what your `.importjs.json` configuration file
+ImportJS that is older than what your `.importjs.js` configuration file
 requires. If your plugin version is older than this value, you will be shown a
 warning that encourages you to upgrade your plugin.
 
@@ -439,7 +438,7 @@ release. See [Dynamic Configuration](#dynamic-configuration) for a better way
 of accomplishing the same thing_.
 _
 You can dynamically apply configuration to different directory trees within your
-project by turning the `.importjs.json` file into an array of configuration
+project by turning the `.importjs.js` file into an array of configuration
 objects. Each configuration specifies what part of the tree it applies to
 through the `appliesTo` and `appliesFrom` options.
 

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -144,7 +144,7 @@ function checkCurrentVersion(minimumVersion: string) {
   }
 
   throw Error(
-    'The .importjs.json file for this project requires version ' +
+    'The configuration file for this project requires version ' +
     `${minimumVersion} or newer. You are using ${version()}.`
   );
 }
@@ -177,7 +177,7 @@ function mergedValue(
   return mergedResult;
 }
 
-// Class that initializes configuration from a .importjs.json file
+// Class that initializes configuration from a .importjs.js file
 export default class Configuration {
   pathToCurrentFile: string;
   messages: Array<string>;
@@ -282,11 +282,11 @@ export default class Configuration {
   }
 
   loadUserConfig(): ?Object {
-    const config = FileUtils.readJsFile(
+    const jsConfig = FileUtils.readJsFile(
       path.join(this.workingDirectory, JS_CONFIG_FILE)
     );
 
-    if (config && Object.keys(config).length === 0) {
+    if (jsConfig && Object.keys(jsConfig).length === 0) {
       // If you forget to use `module.exports`, the config object will be `{}`.
       // To prevent subtle errors from happening, we surface an error message to
       // the user.
@@ -295,8 +295,20 @@ export default class Configuration {
         '`module.exports` to specify what gets exported from the file.');
     }
 
-    return config || FileUtils.readJsonFile(
+    if (jsConfig) {
+      return jsConfig;
+    }
+
+    const jsonConfig = FileUtils.readJsonFile(
       path.join(this.workingDirectory, JSON_CONFIG_FILE));
+
+    if (jsonConfig) {
+      this.messages.push(
+        'Using JSON to configure ImportJS is deprecated and will go away ' +
+        'in a future version. Use an `.importjs.js` file instead.');
+    }
+
+    return jsonConfig;
   }
 
   resolveAlias(variableName: string, pathToCurrentFile: ?string): ?JsModule {

--- a/lib/__tests__/Configuration-test.js
+++ b/lib/__tests__/Configuration-test.js
@@ -20,7 +20,7 @@ describe('Configuration', () => {
 
   describe('with camelCased configuration', () => {
     beforeEach(() => {
-      FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+      FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
         declarationKeyword: 'const',
       });
     });
@@ -33,7 +33,7 @@ describe('Configuration', () => {
 
   describe('with deprecated snake_cased configuration', () => {
     beforeEach(() => {
-      FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+      FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
         declaration_keyword: 'const',
       });
     });
@@ -53,7 +53,7 @@ describe('Configuration', () => {
 
   describe('with unknown configuration', () => {
     beforeEach(() => {
-      FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+      FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
         somethingStrange: true,
       });
     });
@@ -83,6 +83,14 @@ describe('Configuration', () => {
 
       it('returns the configured value for the key', () => {
         expect(new Configuration().get('aliases')).toEqual({ foo: 'bar' });
+      });
+
+      it('has a deprecation message', () => {
+        const configuration = new Configuration();
+        expect(configuration.messages).toEqual([
+          'Using JSON to configure ImportJS is deprecated and will go away ' +
+          'in a future version. Use an `.importjs.js` file instead.',
+        ]);
       });
 
       describe('and a javascript configuration file', () => {
@@ -128,7 +136,7 @@ describe('Configuration', () => {
 
     describe('with a minimumVersion', () => {
       beforeEach(() => {
-        FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
           minimumVersion: '1.2.3',
         });
       });
@@ -141,7 +149,7 @@ describe('Configuration', () => {
       it('throws an error when current version is older', () => {
         version.__setVersion('1.2.2');
         expect(() => new Configuration()).toThrow(new Error(
-          'The .importjs.json file for this project requires version ' +
+          'The configuration file for this project requires version ' +
           '1.2.3 or newer. You are using 1.2.2.'
         ));
       });
@@ -192,7 +200,7 @@ describe('Configuration', () => {
 
     describe('with multiple configurations', () => {
       beforeEach(() => {
-        FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), [
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), [
           {
             declarationKeyword: 'const',
             importFunction: 'foobar',
@@ -248,7 +256,7 @@ describe('Configuration', () => {
 
     describe('with appliesFrom', () => {
       beforeEach(() => {
-        FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), [
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), [
           {
             declarationKeyword: 'const',
           },
@@ -288,7 +296,7 @@ describe('Configuration', () => {
     describe('in a meteor environment', () => {
       beforeEach(() => {
         FileUtils.__setFile(
-          path.join(process.cwd(), '.importjs.json'),
+          path.join(process.cwd(), '.importjs.js'),
           { environments: ['meteor'] });
       });
 
@@ -317,7 +325,7 @@ describe('Configuration', () => {
     describe('in a node environment', () => {
       beforeEach(() => {
         FileUtils.__setFile(
-          path.join(process.cwd(), '.importjs.json'),
+          path.join(process.cwd(), '.importjs.js'),
           { environments: ['node'] });
       });
 
@@ -363,7 +371,7 @@ describe('Configuration', () => {
     describe('in multiple environments', () => {
       beforeEach(() => {
         FileUtils.__setFile(
-          path.join(process.cwd(), '.importjs.json'),
+          path.join(process.cwd(), '.importjs.js'),
           { environments: ['node', 'meteor'] });
       });
 
@@ -380,7 +388,7 @@ describe('Configuration', () => {
       // TODO: replace the array-style configuration here when we have an
       // environment that specify aliases.
       FileUtils.__setFile(
-        path.join(process.cwd(), '.importjs.json'),
+        path.join(process.cwd(), '.importjs.js'),
         [
           {
             aliases: {
@@ -413,7 +421,7 @@ describe('Configuration', () => {
     describe('in meteor environment', () => {
       describe('with no side-effect imports for a component', () => {
         beforeEach(() => {
-          FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+          FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
             useRelativePaths: true,
             environments: ['meteor'],
           });
@@ -427,7 +435,7 @@ describe('Configuration', () => {
 
       describe('with useRelativePaths true', () => {
         beforeEach(() => {
-          FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+          FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
             useRelativePaths: true,
             environments: ['meteor'],
           });
@@ -463,7 +471,7 @@ describe('Configuration', () => {
 
       describe('with useRelativePaths false', () => {
         beforeEach(() => {
-          FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+          FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
             useRelativePaths: false,
             environments: ['meteor'],
           });
@@ -493,7 +501,7 @@ describe('Configuration', () => {
       // TODO: replace the array-style configuration here when we have an
       // environment that specify namedExports.
       FileUtils.__setFile(
-        path.join(process.cwd(), '.importjs.json'),
+        path.join(process.cwd(), '.importjs.js'),
         [
           {
             namedExports: {
@@ -518,7 +526,7 @@ describe('Configuration', () => {
 
   describe('#get namedExports from meteor environment', () => {
     beforeEach(() => {
-      FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+      FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
         environments: ['meteor'],
       });
       fs.__setFile(path.join(process.cwd(), '.meteor', 'packages'), `
@@ -624,7 +632,7 @@ jane:bar@0.0.1
   describe('#get lookupPaths', () => {
     beforeEach(() => {
       FileUtils.__setFile(
-        path.join(process.cwd(), '.importjs.json'),
+        path.join(process.cwd(), '.importjs.js'),
         [
           {
             lookupPaths: ['foo'],
@@ -700,7 +708,7 @@ jane:bar@0.0.1
 
       describe('when importDevDependencies is true', () => {
         beforeEach(() => {
-          FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+          FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
             importDevDependencies: true,
           });
         });
@@ -728,7 +736,7 @@ jane:bar-foo@1.0.0   # version to be stripped
             bar: '2.0.0',
           },
         });
-        FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'),
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'),
           { environments: ['meteor'] });
       });
 

--- a/lib/__tests__/ImportStatements-test.js
+++ b/lib/__tests__/ImportStatements-test.js
@@ -116,7 +116,7 @@ describe('ImportStatements', () => {
 
     describe('with a meteor environment', () => {
       beforeEach(() => {
-        FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
           environments: ['meteor'],
           packageDependencies: ['meteor/bar'],
         });
@@ -175,7 +175,7 @@ describe('ImportStatements', () => {
 
     describe('with a node environment', () => {
       beforeEach(() => {
-        FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
           environments: ['node'],
         });
       });
@@ -228,7 +228,7 @@ describe('ImportStatements', () => {
 
   describe('when groupImports is false', () => {
     beforeEach(() => {
-      FileUtils.__setFile(path.join(process.cwd(), '.importjs.json'), {
+      FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
         groupImports: false,
       });
     });

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -32,8 +32,10 @@ describe('Importer', () => {
     configuration = {};
 
     setup = () => {
-      FileUtils.__setFile(
-        path.join(process.cwd(), '.importjs.json'), configuration);
+      if (Object.keys(configuration).length) {
+        FileUtils.__setFile(
+          path.join(process.cwd(), '.importjs.js'), configuration);
+      }
 
       // Convert the array to an object, as it is in the package.json file.
       const dependencies = packageDependencies.reduce((depsObj, dependency) => (


### PR DESCRIPTION
If you continue to use the JSON configuration format, you'll see a
deprecation message every time you import something:

  Using JSON to configure ImportJS is deprecated and will go away
  in a future version. Use an `.importjs.js` file instead.

Deprecating this now will allow us to remove it in the future, and
hopefully move faster because we have less features to maintain.

[Fixes #326]