### PR TITLE
Remove unused code in JsModule#resolvedFilePath

### DIFF
--- a/lib/JsModule.js
+++ b/lib/JsModule.js
@@ -154,17 +154,7 @@ export default class JsModule {
     workingDirectory: string = process.cwd()
   ): string {
     if (this.filePath) {
-      // There is a filePath. This happens for JSModules that are not aliases.
-      if (!this.filePath.startsWith('/package.json')) {
-        return this.filePath;
-      }
-
-      if (this.mainFile) {
-        // The filePath points to a package.json file, so we want to look in
-        // that package.json file for a `main` configuration value and open that
-        // file instead.
-        return this.filePath.replace(/package\.json$/, this.mainFile);
-      }
+      return this.filePath;
     }
 
     // There is no filePath. This likely means that we are working with an


### PR DESCRIPTION
We use the resolved file path in the `goto` method, and when we pass in
`pathToImportedModule` to configuration functions. If the file found for
a module is a package.json, we want to use the `main` file when
resolving the "true" file path. When we converted this project from Ruby
to JavaScript, I made a mistake when converting some code handling this.
`startsWith` should have been `endsWith`. We have tests around this, and
they are passing even with the faulty code in place. Which means we are
handling it somewhere else. A quick git-blame led me to 5b9b1031 which
adds code that replaces package.json with the main file:

  if (mainFile) {
    jsModule.filePath = `${importPath}/${mainFile}`;
  }

The fix is to simply remove the faulty code.

[Fixes #335]