### PR TITLE
Add `importjsd logpath` take 2

### DIFF
--- a/bin/importjsd.js
+++ b/bin/importjsd.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../build/daemon.js')();
+require('../build/daemon.js')(process.argv);

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -23,80 +23,97 @@ const commandsToFunctionNames = {
   add: 'addImports',
 };
 
-commander.option('--parent-pid <n>', parseInt).parse(process.argv);
+commander.command('start')
+  .description('start the daemon')
+  .option('--parent-pid <n>', parseInt)
+  .action(() => {
+    // The `importjsd` here is mostly a dummy file because config relies on a
+    // `pathToCurrentFile`. Normally, this is the javascript file you are editing.
+    const config = new Configuration('importjsd');
 
-export default function daemon() {
-  // The `importjsd` here is mostly a dummy file because config relies on a
-  // `pathToCurrentFile`. Normally, this is the javascript file you are editing.
-  const config = new Configuration('importjsd');
-
-  loglevel.setLevel(config.get('logLevel'));
-  loglevelMessagePrefix(loglevel, {
-    prefixes: ['timestamp', 'level'],
-    staticPrefixes: [`PID:${commander.parentPid}`],
-  });
-  originalConsoleLog(
-    `ImportJS (v${version()}) DAEMON active. Logs will go to: ${pathToLogFile}`);
-
-  WatchmanFileCache.getForWorkingDirectory(process.cwd()).initialize()
-    .then(() => {
-      loglevel.info(`WATCHMAN file cache is enabled for ${process.cwd()}`);
-    })
-    .catch((err: Object) => {
-      loglevel.info(
-        `WATCHMAN file cache is not available. Reason:\n${err.stack}`);
+    loglevel.setLevel(config.get('logLevel'));
+    loglevelMessagePrefix(loglevel, {
+      prefixes: ['timestamp', 'level'],
+      staticPrefixes: [`PID:${commander.parentPid}`],
     });
+    originalConsoleLog(
+      `ImportJS (v${version()}) DAEMON active. Logs will go to: ${pathToLogFile}`);
 
-  if (commander.parentPid) {
-    // Editor plugins should provide a `--parent-pid=<pid>` argument on startup,
-    // so that we can check that the daemon process hasn't turned into a zombie
-    // once in a while.
-    setInterval(() => {
-      loglevel.debug('Making sure that the parent process ' +
-                     `(PID=${commander.parentPid}) is still running.`);
-      try {
-        process.kill(commander.parentPid, 0);
-      } catch (error) {
-        loglevel.info('Parent process seems to have died. Exiting.');
-        process.exit(1);
-      }
-    }, 30000);
-  }
+    WatchmanFileCache.getForWorkingDirectory(process.cwd()).initialize()
+      .then(() => {
+        loglevel.info(`WATCHMAN file cache is enabled for ${process.cwd()}`);
+      })
+      .catch((err: Object) => {
+        loglevel.info(
+          `WATCHMAN file cache is not available. Reason:\n${err.stack}`);
+      });
 
-  const rlInterface = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-    terminal: false,
-  });
-
-  rlInterface.on('line', (jsonPayload: string) => {
-    loglevel.debug(`RECEIVED payload: ${jsonPayload}`);
-    // The json payload is an array containing a job id and job details.
-    const payload = JSON.parse(jsonPayload);
-    const importer = new Importer(
-      payload.fileContent.split('\n'), payload.pathToFile);
-
-    const functionName = commandsToFunctionNames[payload.command];
-    if (!functionName) {
-      const errorString =
-        `Unknown command: ${payload.command}. ` +
-        `Valid ones are ${Object.keys(commandsToFunctionNames).join(', ')}`;
-      loglevel.error(errorString);
-      const jsonResponse = JSON.stringify({ error: errorString });
-      process.stdout.write(`${jsonResponse}\n`);
-      return;
+    if (commander.parentPid) {
+      // Editor plugins should provide a `--parent-pid=<pid>` argument on startup,
+      // so that we can check that the daemon process hasn't turned into a zombie
+      // once in a while.
+      setInterval(() => {
+        loglevel.debug('Making sure that the parent process ' +
+                      `(PID=${commander.parentPid}) is still running.`);
+        try {
+          process.kill(commander.parentPid, 0);
+        } catch (error) {
+          loglevel.info('Parent process seems to have died. Exiting.');
+          process.exit(1);
+        }
+      }, 30000);
     }
 
-    importer[functionName](payload.commandArg).then((result: Object) => {
-      const jsonResponse = JSON.stringify(result);
-      loglevel.debug(`SENDING response: ${jsonResponse}`);
-      process.stdout.write(`${jsonResponse}\n`);
-    }).catch((error: Object) => {
-      const jsonResponse = JSON.stringify({
-        error: error.stack,
+    const rlInterface = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false,
+    });
+
+    rlInterface.on('line', (jsonPayload: string) => {
+      loglevel.debug(`RECEIVED payload: ${jsonPayload}`);
+      // The json payload is an array containing a job id and job details.
+      const payload = JSON.parse(jsonPayload);
+      const importer = new Importer(
+        payload.fileContent.split('\n'), payload.pathToFile);
+
+      const functionName = commandsToFunctionNames[payload.command];
+      if (!functionName) {
+        const errorString =
+          `Unknown command: ${payload.command}. ` +
+          `Valid ones are ${Object.keys(commandsToFunctionNames).join(', ')}`;
+        loglevel.error(errorString);
+        const jsonResponse = JSON.stringify({ error: errorString });
+        process.stdout.write(`${jsonResponse}\n`);
+        return;
+      }
+
+      importer[functionName](payload.commandArg).then((result: Object) => {
+        const jsonResponse = JSON.stringify(result);
+        loglevel.debug(`SENDING response: ${jsonResponse}`);
+        process.stdout.write(`${jsonResponse}\n`);
+      }).catch((error: Object) => {
+        const jsonResponse = JSON.stringify({
+          error: error.stack,
+        });
+        loglevel.error(`ERROR response: ${jsonResponse}`);
+        process.stdout.write(`${jsonResponse}\n`);
       });
-      loglevel.error(`ERROR response: ${jsonResponse}`);
-      process.stdout.write(`${jsonResponse}\n`);
     });
   });
+
+commander.command('logpath')
+  .description('show path to log file')
+  .action(() => {
+    process.stdout.write(`${pathToLogFile}\n`);
+  });
+
+export default function daemon(argv: Array<string>) {
+  const args = argv;
+  if (args.length <= 2) {
+    // no arguments were given, so default to start
+    args.push('start');
+  }
+
+  commander.parse(args);
 }


### PR DESCRIPTION
My original attempt was reverted by 5c5c3ea7 because it broke the
--parent-pid option. I fixed this by using the commander API a little
better.

This commander package has confusing behavior. Specifically around the
`.command()` function. Apparently if you give it a description argument,
it will treat it like git-style subcommands which means that it looks
for a different file for the action instead of allowing the action to be
defined. And, if you don't specify a description, there isn't a built-in
way to set a command as default via the `isDefault` option. I worked
around this by modifying the arguments that are parsed to set my own
default. Feels a bit hacky, but it works.