### PR TITLE
Use `const` as declaration keyword in node environment

### DIFF
--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -659,20 +659,16 @@ Meteor
         });
       });
 
-      describe('in a node environment', () => {
-        beforeEach(() => {
-          word = 'Readline';
-          text = 'Readline';
-          configuration.environments = ['node'];
-        });
+      it('adds a require to the top of the buffer in a node environment', () => {
+        word = 'Readline';
+        text = 'Readline';
+        configuration.environments = ['node'];
 
-        it('adds an import to the top of the buffer', () => {
-          expect(subject()).toEqual(`
-import Readline from 'readline';
+        expect(subject()).toEqual(`
+const Readline = require('readline');
 
 Readline
-          `.trim());
-        });
+        `.trim());
       });
 
       describe('when the import resolves to a dependency from package.json', () => {

--- a/lib/environments/nodeEnvironment.js
+++ b/lib/environments/nodeEnvironment.js
@@ -1,4 +1,6 @@
 export default {
+  declarationKeyword: 'const',
+
   // As listed in https://github.com/nodejs/node/tree/master/lib
   //
   // Note that we do not include `process` in this list because that is


### PR DESCRIPTION
This is typical for the node environment, and likely will be until node
gets `import`s. People who are transpiling their code in node can still
override this by setting `declarationKeyword` in their configuration.

Fixes #235
