### PR TITLE
Default importjsd to --help instead of start

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -109,11 +109,10 @@ commander.command('logpath')
   });
 
 export default function daemon(argv: Array<string>) {
-  const args = argv;
-  if (args.length <= 2) {
-    // no arguments were given, so default to start
-    args.push('start');
-  }
+  commander.parse(argv);
 
-  commander.parse(args);
+  if (argv.length <= 2) {
+    // no arguments were given, so default to help
+    commander.help();
+  }
 }


### PR DESCRIPTION
This currently does not work correctly when used like `importjsd
--parent-pid n`, which has caused some breakages in our editor plugins.
Since this does not seem to be a thing that commander.js likes to do
very easily, I think the best path forward at this point is to simply
default to `--help` instead.

I've already updated the editor plugins to use `importjsd start
--parent-pid n`.

Fixes #345