### PR TITLE
Make it clearer that 'memoize' is a namedExports

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ namedExports: {
   underscore: [
     'omit',
     'debounce',
+    'memoize'
   ],
   'lib/utils': [
     'escape',


### PR DESCRIPTION
Even though that feature is deprecated, it might be more clear to see that `memoize` was defend as `namedExports`
before we use it on the next example (`import { memoize } from 'underscore';`)