### PR TITLE
Fix support for namespace imports

### DIFF
--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -670,9 +670,9 @@ foo
 
           it('adds the import and sorts the entire list with groups', () => {
             expect(subject()).toEqual(`
-import * as starBar from './star/bar';
 import bar from './foo/bar';
 import foo from './bar/foo';
+import * as starBar from './star/bar';
 import zoo from './foo/zoo'
 
 const sko = customImportFunction('./sko');
@@ -688,10 +688,10 @@ foo
 
             it('adds the import and sorts all of them', () => {
               expect(subject()).toEqual(`
-import * as starBar from './star/bar';
 import bar from './foo/bar';
 import foo from './bar/foo';
 const sko = customImportFunction('./sko');
+import * as starBar from './star/bar';
 import zoo from './foo/zoo'
 
 foo
@@ -1952,6 +1952,25 @@ foo; bar;
 const foo = require('foo');
 
 foo();
+        `.trim();
+      });
+
+      it('leaves the buffer unchanged', () => {
+        expect(subject()).toEqual(text);
+      });
+
+      it('displays no message', () => {
+        subject();
+        expect(result.messages).toEqual([]);
+      });
+    });
+
+    describe('with unconventional imports', () => {
+      beforeEach(() => {
+        text = `
+import * as foo from 'foo';
+
+foo.bar();
         `.trim();
       });
 

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1965,7 +1965,7 @@ foo();
       });
     });
 
-    describe('with unconventional imports', () => {
+    describe('with a namespaced import', () => {
       beforeEach(() => {
         text = `
 import * as foo from 'foo';

--- a/lib/__tests__/findCurrentImports-test.js
+++ b/lib/__tests__/findCurrentImports-test.js
@@ -60,6 +60,26 @@ module.exports = AlignmentRibbonPage;
   expect(imports.range.end).toEqual(1);
 });
 
+it('finds namespace imports', () => {
+  const currentFileContent = `
+import * as api from './api'
+  `.trim();
+
+  const imports = findCurrentImports(
+    new Configuration('./foo.js'),
+    currentFileContent,
+    parse(currentFileContent),
+  );
+  expect(imports.imports.size()).toEqual(1);
+  imports.imports.forEach((imp) => {
+    expect(imp.path).toEqual('./api');
+    expect(imp.declarationKeyword).toEqual('import');
+    expect(imp.defaultImport).toEqual('api');
+  });
+  expect(imports.range.start).toEqual(0);
+  expect(imports.range.end).toEqual(1);
+});
+
 it('stops when it finds a non-import', () => {
   const currentFileContent = `
 const Foo = Bar;

--- a/lib/__tests__/findUndefinedIdentifiers-test.js
+++ b/lib/__tests__/findUndefinedIdentifiers-test.js
@@ -87,6 +87,14 @@ it('knows about nested binary expression trees', () => {
   ]));
 });
 
+it('knows about namespace imports', () => {
+  expect(findUndefinedIdentifiers(parse(`
+    import * as api from './api'
+
+    api.get();
+  `))).toEqual(new Set([]));
+});
+
 it('knows about objects', () => {
   expect(findUndefinedIdentifiers(parse(`
     foo({

--- a/lib/__tests__/findUsedIdentifiers-test.js
+++ b/lib/__tests__/findUsedIdentifiers-test.js
@@ -3,10 +3,11 @@ import parse from '../parse';
 
 it('finds used variables', () => {
   expect(findUsedIdentifiers(parse(`
+    api.something();
     const foo = 'foo';
     foo();
     bar();
-  `))).toEqual(new Set(['foo', 'bar']));
+  `))).toEqual(new Set(['api', 'foo', 'bar']));
 });
 
 it('knows about jsx', () => {

--- a/lib/findCurrentImports.js
+++ b/lib/findCurrentImports.js
@@ -7,7 +7,9 @@ import ImportStatements from './ImportStatements';
 function convertToImportStatement(node: Object): ?ImportStatement {
   if (node.type === 'ImportDeclaration') {
     const defaultSpecifier = node.specifiers.find((spec: Object): boolean =>
-        spec.type === 'ImportDefaultSpecifier');
+        spec.type === 'ImportDefaultSpecifier' ||
+        spec.type === 'ImportNamespaceSpecifier');
+
     return new ImportStatement({
       declarationKeyword: 'import',
       defaultImport: defaultSpecifier ? defaultSpecifier.local.name : undefined,


### PR DESCRIPTION
When running fix imports on something that looked like this

  import * as foo from 'foo';

...we would incorrectly remove the import. This was because we weren't
properly identifying the "as foo" part as an assignment.

Since I usually don't use imports of this type, I worry that we'll
regress in the future. Even though the fix could have been isolated to
findCurrentImports, I decided to flesh out a few other tests just to
make sure we have better coverage for the fix.

Fixes #369. Thanks to @asfktz for the report!