### PR TITLE
Pick first match for goto

### DIFF
--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -98,8 +98,16 @@ export default class Importer {
         variableName,
         this.pathToCurrentFile
       ).then((jsModules: Array<JsModule>) => {
-        const jsModule = this.resolveModuleUsingCurrentImports(
+        let jsModule = this.resolveModuleUsingCurrentImports(
           jsModules, variableName);
+
+        if (!jsModule) {
+          // If the module couldn't be resolved using existing imports, we just
+          // grab the first one. This isn't ideal if there are multiple matches,
+          // but it's rare that we end up here, and falling back to the first
+          // one simplifies things.
+          jsModule = jsModules[0];
+        }
 
         if (!jsModule) {
           // The current word is not mappable to one of the JS modules that we
@@ -233,8 +241,10 @@ export default class Importer {
             return;
           }
 
+          const { variableName } = jsModules[0];
           const jsModule = this.resolveModuleUsingCurrentImports(
-            jsModules, jsModules[0].variableName);
+            jsModules, variableName) ||
+            this.resolveOneJsModule(jsModules, variableName);
 
           if (!jsModule) {
             return;
@@ -364,8 +374,7 @@ export default class Importer {
     });
 
     if (!matchingImportStatement) {
-      // Fall back to asking the user to resolve the ambiguity
-      return this.resolveOneJsModule(jsModules, variableName);
+      return undefined;
     }
 
     if (jsModules.length > 0) {

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -2844,32 +2844,14 @@ foo
     describe('with a variable name that matches multiple files', () => {
       beforeEach(() => {
         existingFiles = [
-          'bar/foo.jsx',
           'car/foo.jsx',
+          'bar/foo.jsx',
         ];
       });
 
       describe('when the variable has not been previously imported', () => {
-        it('displays a message about selecting a module', () => {
-          subject();
-          expect(result.unresolvedImports).toEqual({
-            foo: [
-              {
-                displayName: './bar/foo',
-                importPath: './bar/foo',
-                filePath: './bar/foo.jsx',
-              },
-              {
-                displayName: './car/foo',
-                importPath: './car/foo',
-                filePath: './car/foo.jsx',
-              },
-            ],
-          });
-        });
-
-        it('does not open the file', () => {
-          expect(subject()).not.toBeDefined();
+        it('falls back to the file sorted at the top of the list', () => {
+          expect(subject()).toEqual(path.join(process.cwd(), 'bar/foo.jsx'));
         });
       });
 
@@ -2877,14 +2859,14 @@ foo
         describe('as a default import', () => {
           beforeEach(() => {
             text = `
-import foo from './bar/foo';
+import foo from './car/foo';
 
 foo
             `.trim();
           });
 
           it('opens the file', () => {
-            expect(subject()).toEqual(path.join(process.cwd(), 'bar/foo.jsx'));
+            expect(subject()).toEqual(path.join(process.cwd(), 'car/foo.jsx'));
           });
 
           describe('and there are other imports', () => {


### PR DESCRIPTION
When using `goto` and the word couldn't be matched to a single file, we
would send back a list of `unresolvedImports` to the editor plugin.
However, none of the editor plugins (sublime, vim, emacs, atom) knows
how to resolve ambiguities for goto. In most cases, the goto path can be
resolved using current imports. In the rare event that it can't be
resolved, we now just pick the first one in the list.

This is a quick-fix to a problem that could be address more
holistically. But the more involved fix would include updating all the
plugins, and that's something I'd like to avoid right now.