### PR TITLE
Prevent findExports from blowing up on object spread syntax

### DIFF
--- a/lib/__tests__/findExports-test.js
+++ b/lib/__tests__/findExports-test.js
@@ -61,6 +61,15 @@ it('finds es6 exports', () => {
   });
 });
 
+it('does not blow up on object spreads', () => {
+  expect(findExports(`
+    const foo = { ...bar, baz: true };
+  `)).toEqual({
+    named: [],
+    hasDefault: false,
+  });
+});
+
 it('finds CommonJS exports', () => {
   expect(findExports(`
     const bar = function() {};

--- a/lib/findExports.js
+++ b/lib/findExports.js
@@ -116,8 +116,10 @@ function findDefinedNames(node, definedNames) {
       return;
     }
     if (init.type === 'ObjectExpression') {
-      definedNames[id.name] = // eslint-disable-line no-param-reassign
-        init.properties.map(({ key }) => key.name).filter(Boolean);
+      // eslint-disable-next-line no-param-reassign
+      definedNames[id.name] = init.properties
+        .map(({ key }) => key && key.name)
+        .filter(Boolean);
     } else if (init.type === 'FunctionExpression') {
       definedNames[id.name] = []; // eslint-disable-line no-param-reassign
     }


### PR DESCRIPTION
I have some files that use object spread, e.g.:

```js
const foo = { ...bar, baz: true };
```

In this scenario, `key` is undefined. To prevent this from blowing up,
we need to make sure that `key` exists before trying to access its
`name` property.

There might be an opportunity to improve export detection to follow
object spreads, but that's out of the scope of this bugfix.

Fixes #373.