### PR TITLE
Exclude later

### DIFF
--- a/.importjs.js
+++ b/.importjs.js
@@ -12,7 +12,7 @@ module.exports = {
   logLevel: 'debug',
   excludes: [
     './build/**',
-    './lib/__mocks__/**'
+    './lib/__mocks__/**',
   ],
   importDevDependencies: ({ pathToCurrentFile }) =>
     testFilePattern.test(pathToCurrentFile),

--- a/lib/ModuleFinder.js
+++ b/lib/ModuleFinder.js
@@ -94,11 +94,10 @@ export default class ModuleFinder {
   /**
    * Factory method to get an instance for a specific working directory.
    */
-  static getForWorkingDirectory(workingDirectory, { excludes, ignorePackagePrefixes }) {
+  static getForWorkingDirectory(workingDirectory, { ignorePackagePrefixes }) {
     let instance = instances[workingDirectory];
     if (!instance) {
       instance = new ModuleFinder(workingDirectory, {
-        excludes,
         ignorePackagePrefixes,
       });
       instances[workingDirectory] = instance;
@@ -106,14 +105,12 @@ export default class ModuleFinder {
     return instance;
   }
 
-  constructor(workingDirectory, { excludes, ignorePackagePrefixes }) {
-    this.excludes = excludes;
+  constructor(workingDirectory, { ignorePackagePrefixes }) {
     this.ignorePackagePrefixes = ignorePackagePrefixes;
     this.workingDirectory = workingDirectory;
     this.storage = new ExportsStorage();
     this.watcher = new Watcher({
       workingDirectory,
-      excludes,
       onFilesAdded: this.handleFilesAdded.bind(this),
       onFilesRemoved: this.handleFilesRemoved.bind(this),
       storage: this.storage,
@@ -125,8 +122,7 @@ export default class ModuleFinder {
   initializeStorage(dbFilename) {
     return this.storage.init(dbFilename)
       .then(({ isFreshInstall }) =>
-        Promise.all(this.excludes.map((glob) => this.storage.removeAll(glob)))
-        .then(() => this.storage.purgeDeadNodeModules(this.workingDirectory))
+        this.storage.purgeDeadNodeModules(this.workingDirectory)
         .then(() => Promise.resolve({ isFreshInstall })));
   }
 

--- a/lib/Watcher.js
+++ b/lib/Watcher.js
@@ -1,7 +1,6 @@
 // @flow
 
 import fbWatchman from 'fb-watchman';
-import minimatch from 'minimatch';
 import winston from 'winston';
 
 import ExportsStorage from './ExportsStorage';
@@ -12,20 +11,17 @@ const SUBSCRIPTION_NAME = 'import-js-subscription';
 
 export default class Watcher {
   workingDirectory: string;
-  excludes: Array<string>;
   onFilesAdded: Function;
   onFilesRemoved: Function;
   storage: ExportsStorage;
 
   constructor({
     workingDirectory = process.cwd(),
-    excludes = [],
     onFilesAdded = (): Promise<void> => Promise.resolve(),
     onFilesRemoved = (): Promise<void> => Promise.resolve(),
     storage,
   }: Object) {
     this.workingDirectory = workingDirectory;
-    this.excludes = excludes;
     this.onFilesAdded = onFilesAdded;
     this.onFilesRemoved = onFilesRemoved;
     this.storage = storage;
@@ -72,10 +68,6 @@ export default class Watcher {
         resp.files.forEach((file: Object) => {
           const normalizedPath = normalizePath(file.name, this.workingDirectory);
           if (normalizedPath.indexOf('/node_modules/') !== -1) {
-            return;
-          }
-          if (this.excludes.some((pattern: string): boolean =>
-            minimatch(normalizedPath, pattern))) {
             return;
           }
           if (file.exists) {
@@ -168,7 +160,7 @@ export default class Watcher {
 
   poll(): Promise<void> {
     return new Promise((resolve: Function, reject: Function) => {
-      findAllFiles(this.workingDirectory, this.excludes)
+      findAllFiles(this.workingDirectory)
         .then((files: Array<Object>) => {
           const mtimes = {};
           files.forEach(({ path: pathToFile, mtime }: Object) => {

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -27,7 +27,6 @@ describe('Importer', () => {
 
   beforeEach(() => {
     moduleFinder = ModuleFinder.getForWorkingDirectory(process.cwd(), {
-      excludes: [],
       ignorePackagePrefixes: [],
     });
     return moduleFinder.initializeStorage(':memory:');

--- a/lib/__tests__/ModuleFinder-test.js
+++ b/lib/__tests__/ModuleFinder-test.js
@@ -36,7 +36,6 @@ beforeEach(() => {
   );
 
   moduleFinder = ModuleFinder.getForWorkingDirectory(process.cwd(), {
-    excludes: [],
     ignorePackagePrefixes: ['react-'],
   });
   return moduleFinder.initializeStorage(':memory:');

--- a/lib/__tests__/findAllFiles-test.js
+++ b/lib/__tests__/findAllFiles-test.js
@@ -10,19 +10,6 @@ it('has mtimes', () =>
     expect(files[0].mtime).toBeGreaterThan(0);
   }));
 
-it('excludes files', () =>
-  findAllFiles(process.cwd(), ['./**/__test__/**']).then((files) => {
-    expect(files.length).toBeGreaterThan(0);
-
-    const testFiles = files.map(({ path }) => path)
-      .filter((path) => /__test__/.test(path));
-    expect(testFiles).toEqual([]);
-
-    const libFiles = files.map(({ path }) => path)
-      .filter((path) => /lib/.test(path));
-    expect(libFiles.length).toBeGreaterThan(0);
-  }));
-
 it('excludes node_modules', () =>
   findAllFiles(process.cwd(), []).then((files) => {
     const nodeModules = files.map(({ path }) => path)

--- a/lib/__tests__/findJsModulesFor-test.js
+++ b/lib/__tests__/findJsModulesFor-test.js
@@ -1,0 +1,41 @@
+import path from 'path';
+
+import Configuration from '../Configuration';
+import FileUtils from '../FileUtils';
+import ModuleFinder from '../ModuleFinder';
+import findJsModulesFor from '../findJsModulesFor';
+
+jest.mock('../ModuleFinder');
+jest.mock('../FileUtils');
+
+beforeEach(() => {
+  ModuleFinder.getForWorkingDirectory.mockImplementation(() => ({
+    find() {
+      return Promise.resolve([{ path: './foo.js', isDefault: true }]);
+    },
+  }));
+});
+
+it('returns matching modules', () => findJsModulesFor(
+  new Configuration('./bar.js'),
+  'foo',
+  './bar.js'
+).then((jsModules) => {
+  expect(jsModules.length).toEqual(1);
+}));
+
+describe('when a matching module is excluded', () => {
+  beforeEach(() => {
+    FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+      excludes: ['./*.js'],
+    });
+  });
+
+  it('strips it out', () => findJsModulesFor(
+    new Configuration('./bar.js'),
+    'foo',
+    './bar.js'
+  ).then((jsModules) => {
+    expect(jsModules.length).toEqual(0);
+  }));
+});

--- a/lib/findAllFiles.js
+++ b/lib/findAllFiles.js
@@ -2,10 +2,10 @@ import glob from 'glob';
 
 import lastUpdate from './lastUpdate';
 
-export default function findAllFiles(workingDirectory, excludes) {
+export default function findAllFiles(workingDirectory) {
   return new Promise((resolve, reject) => {
     glob('./**/*.js*', {
-      ignore: ['./node_modules/**'].concat(excludes),
+      ignore: ['./node_modules/**'],
       cwd: workingDirectory,
     }, (err, files) => {
       if (err) {

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -1,5 +1,6 @@
 // @flow
 
+import minimatch from 'minimatch';
 import sortBy from 'lodash.sortby';
 import uniqBy from 'lodash.uniqby';
 
@@ -48,6 +49,13 @@ function findJsModulesFromModuleFinder(
             hasNamedExports: !isDefault,
           });
         }
+
+        // Filter out modules that are in the `excludes` config.
+        if (config.get('excludes').some((glob: string): boolean =>
+          minimatch(path, glob))) {
+          return undefined;
+        }
+
         return JsModule.construct({
           hasNamedExports: !isDefault,
           relativeFilePath: path,

--- a/lib/initializeModuleFinder.js
+++ b/lib/initializeModuleFinder.js
@@ -33,7 +33,6 @@ export default function initializeModuleFinder(
 ): Promise {
   const config = new Configuration('importjs', workingDirectory);
   const moduleFinder = ModuleFinder.getForWorkingDirectory(workingDirectory, {
-    excludes: config.get('excludes'),
     ignorePackagePrefixes: config.get('ignorePackagePrefixes'),
   });
   if (alreadyInitializedFinders.has(moduleFinder)) {


### PR DESCRIPTION
I ended up pushing two commit here. My first attempt was simply to apply yet another exclusion filter. This made things a little better. But after thinking about implications, I decided to push another more aggressive change that consolidated all the exclusion filtering into one place -- in `findJsModulesFor` at import-time. 