### PR TITLE
Resolve aliases that look like variables

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -266,7 +266,7 @@ export default class Configuration {
     return jsonConfig;
   }
 
-  resolveAlias(variableName: string, pathToCurrentFile: ?string): ?JsModule {
+  resolveAlias(variableName: string, pathToCurrentFile: ?string): ?string {
     let importPath = this.get('aliases')[variableName];
     if (!importPath) {
       return null;
@@ -281,7 +281,7 @@ export default class Configuration {
         path.basename(pathToCurrentFile, path.extname(pathToCurrentFile)),
       );
     }
-    return new JsModule({ importPath, variableName });
+    return importPath;
   }
 
   resolveNamedExports(variableName: string): ?JsModule {

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1150,6 +1150,7 @@ foo
       describe('with aliases', () => {
         beforeEach(() => {
           configuration.aliases = { $: 'jquery' };
+          packageDependencies = ['jquery'];
           text = '$';
           word = '$';
         });

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -29,6 +29,7 @@ const PACKAGE_NAME_PATTERN = /\.\/node_modules\/([^/]+)\//;
 
 function findJsModulesFromModuleFinder(
   config: Configuration,
+  normalizedName: string,
   variableName: string,
   finder: ModuleFinder,
   pathToCurrentFile: string,
@@ -42,7 +43,7 @@ function findJsModulesFromModuleFinder(
     }
 
     finder
-      .find(variableName)
+      .find(normalizedName)
       .then((exports: Array<Object>) => {
         const modules = exports.map((
           { path, isDefault }: Object,
@@ -92,16 +93,27 @@ function dedupeAndSort(modules: Array<JsModule>): Array<JsModule> {
   return sortBy(uniques, (module: JsModule): string => module.displayName());
 }
 
+const NON_PATH_ALIAS_PATTERN = /^[a-zA-Z0-9-_]+$/;
+
 export default function findJsModulesFor(
   config: Configuration,
   variableName: string,
   pathToCurrentFile: string,
 ): Promise<Array<JsModule>> {
   return new Promise((resolve: Function, reject: Function) => {
-    const aliasModule = config.resolveAlias(variableName, pathToCurrentFile);
-    if (aliasModule) {
-      resolve([aliasModule]);
-      return;
+    let normalizedName = variableName;
+    const alias = config.resolveAlias(variableName, pathToCurrentFile);
+    if (alias) {
+      if (NON_PATH_ALIAS_PATTERN.test(alias)) {
+        // The alias is likely a package dependency. We can use it in the
+        // ModuleFinder lookup.
+        normalizedName = alias;
+      } else {
+        // The alias is a path of some sort. Use it directly as the moduleName
+        // in the import.
+        resolve([new JsModule({ importPath: alias, variableName })]);
+        return;
+      }
     }
 
     const namedImportsModule = config.resolveNamedExports(variableName);
@@ -123,6 +135,7 @@ export default function findJsModulesFor(
     );
     findJsModulesFromModuleFinder(
       config,
+      normalizedName,
       variableName,
       finder,
       pathToCurrentFile,


### PR DESCRIPTION
In the Meteor environment, we have a moduleNameFormatter that will add a
slash at the beginning of paths that

- aren't a node module
- do not start with a dot

For package dependency aliases (e.g. $ => jquery) this ended up messing
up the moduleName ("/jquery"). By using the alias in a lookup from the
ModuleFinder, we make sure that by the time we hit moduleNameFormatter,
we have enough information (i.e. pathToImportedModule) to avoid adding
the slash.

Fixes #381