### PR TITLE
Prevent a few instances where the cache gets stale

### DIFF
--- a/lib/ModuleFinder.js
+++ b/lib/ModuleFinder.js
@@ -6,6 +6,7 @@ import ExportsStorage from './ExportsStorage';
 import Watcher from './Watcher';
 import findExports from './findExports';
 import findPackageDependencies from './findPackageDependencies';
+import lastUpdate from './lastUpdate';
 import readFile from './readFile';
 import requireResolve from './requireResolve';
 
@@ -19,32 +20,35 @@ function assumedLocalPath(pathToResolvedPackageFile, packageName) {
  * expands the list of files to include package dependencies if so.
  */
 function expandFiles(files, workingDirectory) {
-  return new Promise((resolve) => {
-    const result = new Set([]);
-    files.forEach((file) => {
-      if (
-        file.path !== './package.json' && file.path !== './npm-shrinkwrap.json'
-      ) {
-        result.add(file);
+  const promises = [];
+  files.forEach((file) => {
+    if (
+      file.path !== './package.json' && file.path !== './npm-shrinkwrap.json'
+    ) {
+      promises.push(Promise.resolve(file));
+      return;
+    }
+    findPackageDependencies(workingDirectory, true).forEach((dep) => {
+      const pathToResolve = path.join(workingDirectory, 'node_modules', dep);
+      const resolvedPath = requireResolve(pathToResolve);
+      if (resolvedPath === pathToResolve) {
+        // Getting back the same value as we sent in means that we couldn't
+        // resolve the dependency to a real file. Ignore this, as we won't be
+        // able to parse it anyway.
         return;
       }
-      findPackageDependencies(workingDirectory, true).forEach((dep) => {
-        const pathToResolve = path.join(workingDirectory, 'node_modules', dep);
-        const resolvedPath = requireResolve(pathToResolve);
-        if (resolvedPath === pathToResolve) {
-          // Ignore
-          return;
-        }
 
-        result.add({
-          path: assumedLocalPath(resolvedPath, dep),
-          mtime: file.mtime,
+      const localPath = assumedLocalPath(resolvedPath, dep);
+
+      promises.push(lastUpdate(localPath, workingDirectory).then(({ mtime }) =>
+        Promise.resolve({
+          path: localPath,
+          mtime,
           alias: dep,
-        });
-      });
+        })));
     });
-    resolve([...result]);
   });
+  return Promise.all(promises);
 }
 
 function aliasedExportNames(alias, ignorePackagePrefixes) {

--- a/lib/__tests__/ModuleFinder-test.js
+++ b/lib/__tests__/ModuleFinder-test.js
@@ -2,6 +2,7 @@ import path from 'path';
 
 import ModuleFinder from '../ModuleFinder';
 import findPackageDependencies from '../findPackageDependencies';
+import lastUpdate from '../lastUpdate';
 import normalizePath from '../normalizePath';
 import readFile from '../readFile';
 import requireResolve from '../requireResolve';
@@ -9,6 +10,7 @@ import requireResolve from '../requireResolve';
 jest.mock('../readFile');
 jest.mock('../findPackageDependencies');
 jest.mock('../requireResolve');
+jest.mock('../lastUpdate');
 
 let moduleFinder;
 
@@ -37,6 +39,11 @@ beforeEach(() => {
     path.join(process.cwd(), 'node_modules/react-packer'),
     path.join(process.cwd(), 'node_modules/react-packer/index.js'),
   );
+
+  lastUpdate.mockImplementation(pathToFile => Promise.resolve({
+    path: pathToFile,
+    mtime: 1,
+  }));
 
   moduleFinder = ModuleFinder.getForWorkingDirectory(process.cwd(), {
     excludes: [],

--- a/lib/__tests__/findJsModulesFor-test.js
+++ b/lib/__tests__/findJsModulesFor-test.js
@@ -19,7 +19,7 @@ beforeEach(() => {
 it('returns matching modules', () => findJsModulesFor(
   new Configuration('./bar.js'),
   'foo',
-  './bar.js'
+  './bar.js',
 ).then((jsModules) => {
   expect(jsModules.length).toEqual(1);
 }));
@@ -34,7 +34,7 @@ describe('when a matching module is excluded', () => {
   it('strips it out', () => findJsModulesFor(
     new Configuration('./bar.js'),
     'foo',
-    './bar.js'
+    './bar.js',
   ).then((jsModules) => {
     expect(jsModules.length).toEqual(0);
   }));

--- a/lib/__tests__/findJsModulesFor-test.js
+++ b/lib/__tests__/findJsModulesFor-test.js
@@ -1,0 +1,41 @@
+import path from 'path';
+
+import Configuration from '../Configuration';
+import FileUtils from '../FileUtils';
+import ModuleFinder from '../ModuleFinder';
+import findJsModulesFor from '../findJsModulesFor';
+
+jest.mock('../ModuleFinder');
+jest.mock('../FileUtils');
+
+beforeEach(() => {
+  ModuleFinder.getForWorkingDirectory.mockImplementation(() => ({
+    find() {
+      return Promise.resolve([{ path: './foo.js', isDefault: true }]);
+    },
+  }));
+});
+
+it('returns matching modules', () => findJsModulesFor(
+  new Configuration('./bar.js'),
+  'foo',
+  './bar.js'
+).then((jsModules) => {
+  expect(jsModules.length).toEqual(1);
+}));
+
+describe('when a matching module is excluded', () => {
+  beforeEach(() => {
+    FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+      excludes: ['./*.js'],
+    });
+  });
+
+  it('strips it out', () => findJsModulesFor(
+    new Configuration('./bar.js'),
+    'foo',
+    './bar.js'
+  ).then((jsModules) => {
+    expect(jsModules.length).toEqual(0);
+  }));
+});

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -1,5 +1,6 @@
 // @flow
 
+import minimatch from 'minimatch';
 import sortBy from 'lodash.sortby';
 import uniqBy from 'lodash.uniqby';
 
@@ -58,6 +59,13 @@ function findJsModulesFromModuleFinder(
               hasNamedExports: !isDefault,
             });
           }
+
+          // Filter out modules that are in the `excludes` config.
+          if (config.get('excludes').some((glob: string): boolean =>
+            minimatch(path, glob))) {
+            return undefined;
+          }
+
           return JsModule.construct({
             hasNamedExports: !isDefault,
             relativeFilePath: path,


### PR DESCRIPTION
This PR fixes two issues where the ExportsStorage cache gets stale: 

- An update to the `excludes` config while the daemon is running has no effect. The supplied fix isn't ideal, but it's making things a little bit better. 

- Use the `mtime` of the package dependencies files themselves instead of using the `mtime` of package.json. 