### PR TITLE
Pass `moduleName` to `importStatementFormatter`

### DIFF
--- a/lib/ImportStatements.js
+++ b/lib/ImportStatements.js
@@ -200,7 +200,7 @@ export default class ImportStatements {
           .map((importString: string): string =>
             this.config.get('importStatementFormatter', {
               importStatement: importString,
-              pathToCurrentFile: this.config.pathToCurrentFile,
+              moduleName: importStatement.path,
             }));
         strings.push(...importStrings);
       });


### PR DESCRIPTION
This can help make manipulating the import statement a little smoother.
As requested in #385.

While I was changing things, I noticed that `pathToCurrentFile` was
passed in the call to `config.get`. This variable is automatically
injected, so there's no need to specify it here.