### PR TITLE
Delay visiting `body` arrays in findUndefinedIdentifiers

### DIFF
--- a/lib/__tests__/findUndefinedIdentifiers-test.js
+++ b/lib/__tests__/findUndefinedIdentifiers-test.js
@@ -164,6 +164,22 @@ it('knows about objects', () => {
   ).toEqual(new Set(['foo', 'uuid']));
 });
 
+it('knows about identifiers declared after usage', () => {
+  expect(
+    findUndefinedIdentifiers(
+      parse(
+        `
+    function modifyAbc() {
+      abc.def = 4;
+    }
+
+    export const abc = {};
+  `,
+      ),
+    ),
+  ).toEqual(new Set([]));
+});
+
 it('handles es6 imports + commonjs + react', () => {
   expect(
     findUndefinedIdentifiers(

--- a/lib/visitIdentifierNodes.js
+++ b/lib/visitIdentifierNodes.js
@@ -56,37 +56,59 @@ function normalizeNode(node, { key, definedInScope, parent }) {
 }
 
 export default function visitIdentifierNodes(
-  node,
+  rootAstNode,
   visitor,
   context = { definedInScope: new Set([]), key: 'root' },
 ) {
-  if (Array.isArray(node)) {
-    node.forEach((child) => {
-      visitIdentifierNodes(child, visitor, context);
-    });
-    return;
-  }
+  const queue = [{ node: rootAstNode, context }];
+  let current;
 
-  const normalizedNode = normalizeNode(node, context);
-  if (normalizedNode) {
-    visitor(normalizedNode);
-  }
-
-  Object.keys(node).forEach((key) => {
-    if (!node[key] || typeof node[key] !== 'object') {
-      return;
+  while (queue.length) {
+    current = queue.shift();
+    if (Array.isArray(current.node)) {
+      if (current.context.key === 'body') {
+        // A new scope has started. Copy whatever we have from the parent scope
+        // into a new one.
+        current.context.definedInScope = new Set([...current.context.definedInScope]);
+      }
+      // eslint-disable-next-line no-loop-func
+      const itemsToAdd = current.node.map(node => ({
+        node,
+        context: current.context,
+      }));
+      queue.unshift(...itemsToAdd);
+      continue; // eslint-disable-line no-continue
     }
-    const newContext = Object.assign({}, context, {
-      key,
-      parent: {
-        type: node.type,
-        parent: context.parent,
-      },
-    });
-    if (key === 'body') {
-      newContext.definedInScope = new Set([...context.definedInScope]);
+    const normalizedNode = normalizeNode(current.node, current.context);
+    if (normalizedNode) {
+      visitor(normalizedNode);
     }
 
-    visitIdentifierNodes(node[key], visitor, newContext);
-  });
+    const itemsToAdd = [];
+    // eslint-disable-next-line no-loop-func
+    Object.keys(current.node).forEach((key) => {
+      if (!current.node[key] || typeof current.node[key] !== 'object') {
+        return;
+      }
+      const newContext = Object.assign({}, current.context, {
+        key,
+        parent: {
+          type: current.node.type,
+          parent: current.context.parent,
+        },
+      });
+      const itemToPush = {
+        node: current.node[key],
+        context: newContext,
+      };
+      if (key === 'body') {
+        // Delay traversing function bodies, so that we can finish finding all
+        // defined variables in scope first.
+        queue.push(itemToPush);
+      } else {
+        itemsToAdd.push(itemToPush);
+      }
+    });
+    queue.unshift(...itemsToAdd);
+  }
 }


### PR DESCRIPTION
When a variable is defined after it being used inside a function scope,
`findUndefinedIdentifiers` would incorrectly flag the variable as
undefined. Here's an example:

  function foo() {
    console.log(bar);
  }

  const bar = 'fake news';

As you can see, `bar` is defined after the function making use of it.
This is perfectly valid javascript, and executing `foo()` would log
`"fake news"` to the console. To take this scenario into account, we had
to delay visiting nodes inside a function body until the parent scope
was "done" (meaning we've found all defined identifiers in it).
Essentially, this meant switching from a depth-first tree traversal to a
breadth-first. I couldn't think of a better way to do that than by
switching from the recursive version that we had before into an iterativ
solution.

This fix ended up being strongly TDD'ed. I'm not completely happy with
where the code ended up, but for now I can't come up with a more elegant
solution.

Fixes #383