### PR TITLE
Find named exports from webpack bundle

### DIFF
--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -98,7 +98,9 @@ export default class Importer {
       this.findOneJsModule(variableName)
         .then((jsModule: JsModule) => {
           if (!jsModule) {
-            this.message(`No JS module to import for \`${variableName}\``);
+            if (!Object.keys(this.unresolvedImports).length) {
+              this.message(`No JS module to import for \`${variableName}\``);
+            }
             resolve(this.results());
             return;
           }

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -930,6 +930,11 @@ foo
           existingFiles = ['bar/foo.jsx', 'zoo/foo.js', 'zoo/goo/Foo/index.js'];
         });
 
+        it('has no messages', () => {
+          subject();
+          expect(result.messages).toEqual([]);
+        });
+
         it('records the alternatives to choose from', () => {
           subject();
           expect(result.unresolvedImports).toEqual({

--- a/lib/__tests__/findExports-test.js
+++ b/lib/__tests__/findExports-test.js
@@ -385,6 +385,35 @@ it('finds underscore exports', () => {
   });
 });
 
+it('finds exports from a webpack bundle', () => {
+  // This is a downsized minimal webpack bundle
+  expect(
+    findExports(
+      `
+ module.exports =
+/******/ (function(modules) { // webpackBootstrap
+/******/ })
+/******/ ({
+/***/ 521:
+/***/ (function(module, exports, __webpack_require__) {
+"use strict";
+exports.Foo = bar;
+exports.default = something;
+exports.createPath = exports.parsePath = exports.getQueryStringValueFromPath = exports.stripQueryStringValueFromPath = exports.addQueryStringValueToPath = undefined;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.Foo = Foo.default;
+/***/ })
+/******/ });
+    `,
+    ),
+  ).toEqual({
+    named: ['Foo'],
+    hasDefault: true,
+  });
+});
+
 it('does not fail for inner exports that are not objects', () => {
   expect(
     findExports(

--- a/lib/findExports.js
+++ b/lib/findExports.js
@@ -224,12 +224,26 @@ function hasDefaultExport(nodes) {
 }
 
 const DEFAULT_EXPORT_PATTERN = /\smodule\.exports\s*=\s*(\w+)/;
-function findRawModuleExportIdentifier(data) {
+function findRawDefaultExport(data) {
   const match = data.match(DEFAULT_EXPORT_PATTERN);
   if (match) {
     return match[1];
   }
   return undefined;
+}
+
+function findRawNamedExports(data) {
+  const result = new Set();
+  const pattern = /^exports\.(\w+)\s*=\s*[\w.]+;$/gm;
+  let match;
+  // eslint-disable-next-line no-cond-assign
+  while ((match = pattern.exec(data)) !== null) {
+    const name = match[1];
+    if (name !== 'default') {
+      result.add(name);
+    }
+  }
+  return Array.from(result);
 }
 
 function findRootNodes(ast) {
@@ -276,11 +290,14 @@ export default function findExports(data, absolutePathToFile) {
   });
   let hasDefault = hasDefaultExport(rootNodes) || aliasesForExports.size > 1;
   if (!hasDefault) {
-    const rawExportedId = findRawModuleExportIdentifier(data);
+    const rawExportedId = findRawDefaultExport(data);
     hasDefault = !!rawExportedId;
     if (!named.length) {
       named.push(...(definedNames[rawExportedId] || []));
     }
+  }
+  if (!named.length) {
+    named.push(...findRawNamedExports(data));
   }
   return {
     named,


### PR DESCRIPTION
We have an application where we have a "client-core" package exporting a
bunch of reusable React components. We bundle these components using
webpack before importing them in other packages.

Before this change, the variables we exported as named exports wouldn't
be found from the webpack bundle. After, they're all correctly
identified.

There are certain things in the exported webpack file that are hard to
keep out of the named exports array. Lines like these:

exports.__esModule = true;

I decided to not worry about them, and just let them be included in the
result. It's unlikely that anyone will try to import something with that
name anyway.