### PR TITLE
Fix `goto` for relative path

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -266,7 +266,7 @@ export default class Configuration {
     return jsonConfig;
   }
 
-  resolveAlias(variableName: string, pathToCurrentFile: ?string): ?string {
+  resolveAlias(variableName: string): ?string {
     let importPath = this.get('aliases')[variableName];
     if (!importPath) {
       return null;
@@ -274,11 +274,11 @@ export default class Configuration {
 
     importPath = importPath.path || importPath; // path may be an object
 
-    if (pathToCurrentFile && pathToCurrentFile.length) {
+    if (this.pathToCurrentFile !== './') {
       // aliases can have dynamic `{filename}` parts
       importPath = importPath.replace(
         /\{filename\}/,
-        path.basename(pathToCurrentFile, path.extname(pathToCurrentFile)),
+        path.basename(this.pathToCurrentFile, path.extname(this.pathToCurrentFile)),
       );
     }
     return importPath;

--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -1,8 +1,6 @@
 // @flow
 import path from 'path';
 
-import escapeRegExp from 'lodash.escaperegexp';
-
 import CommandLineEditor from './CommandLineEditor';
 import Configuration from './Configuration';
 import ImportStatement from './ImportStatement';
@@ -52,21 +50,13 @@ export default class Importer {
 
   constructor(
     lines: Array<string>,
-    pathToFile: ?string,
+    pathToCurrentFile: ?string,
     workingDirectory: string = process.cwd(),
   ) {
-    const pathToCurrentFile = pathToFile || '';
+    this.pathToCurrentFile = pathToCurrentFile || '';
     this.editor = new CommandLineEditor(lines);
-    this.config = new Configuration(pathToCurrentFile, workingDirectory);
+    this.config = new Configuration(this.pathToCurrentFile, workingDirectory);
     this.workingDirectory = workingDirectory;
-
-    // Normalize the path to the current file so that we only have to deal with
-    // local paths.
-    this.pathToCurrentFile = pathToCurrentFile &&
-      pathToCurrentFile.replace(
-        RegExp(`^${escapeRegExp(workingDirectory)}/`),
-        '',
-      );
 
     this.messages = Array.from(this.config.messages);
     this.unresolvedImports = {};
@@ -129,7 +119,7 @@ export default class Importer {
 
   goto(variableName: string): Promise<Object> {
     return new Promise((resolve: Function, reject: Function) => {
-      findJsModulesFor(this.config, variableName, this.pathToCurrentFile)
+      findJsModulesFor(this.config, variableName)
         .then((jsModules: Array<JsModule>) => {
           let jsModule = this.resolveModuleUsingCurrentImports(
             jsModules,
@@ -228,7 +218,7 @@ export default class Importer {
 
       const variables = Object.keys(imports);
       const promises = variables.map((variableName: string): Promise<void> =>
-        findJsModulesFor(this.config, variableName, this.pathToCurrentFile)
+        findJsModulesFor(this.config, variableName)
           .then((jsModules: Array<JsModule>) => {
             const importPath = imports[variableName];
             const foundModule = jsModules.find(
@@ -281,7 +271,7 @@ export default class Importer {
       const promises = variables.map((
         variable: string,
       ): Promise<Array<JsModule>> =>
-        findJsModulesFor(this.config, variable, this.pathToCurrentFile));
+        findJsModulesFor(this.config, variable));
 
       Promise.all(promises)
         .then((results: Array<Array<JsModule>>) => {
@@ -321,7 +311,7 @@ export default class Importer {
 
   findOneJsModule(variableName: string): Promise<JsModule> {
     return new Promise((resolve: Function, reject: Function) => {
-      findJsModulesFor(this.config, variableName, this.pathToCurrentFile)
+      findJsModulesFor(this.config, variableName)
         .then((jsModules: Array<JsModule>) => {
           if (!jsModules.length) {
             resolve(null);

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -33,7 +33,6 @@ function findJsModulesFromModuleFinder(
   normalizedName: string,
   variableName: string,
   finder: ModuleFinder,
-  pathToCurrentFile: string,
 ): Promise<Array<JsModule>> {
   return new Promise((resolve: Function, reject: Function) => {
     let isWantedPackageDependency = Boolean;
@@ -76,7 +75,7 @@ function findJsModulesFromModuleFinder(
             makeRelativeTo: config.get('useRelativePaths', {
               pathToImportedModule: path,
             }) &&
-              pathToCurrentFile,
+              config.pathToCurrentFile,
             variableName,
             workingDirectory: config.workingDirectory,
           });
@@ -106,11 +105,10 @@ const NON_PATH_ALIAS_PATTERN = /^[a-zA-Z0-9-_]+$/;
 export default function findJsModulesFor(
   config: Configuration,
   variableName: string,
-  pathToCurrentFile: string,
 ): Promise<Array<JsModule>> {
   return new Promise((resolve: Function, reject: Function) => {
     let normalizedName = variableName;
-    const alias = config.resolveAlias(variableName, pathToCurrentFile);
+    const alias = config.resolveAlias(variableName);
     if (alias) {
       if (NON_PATH_ALIAS_PATTERN.test(alias)) {
         // The alias is likely a package dependency. We can use it in the
@@ -146,7 +144,7 @@ export default function findJsModulesFor(
       normalizedName,
       variableName,
       finder,
-      pathToCurrentFile,
+      config.pathToCurrentFile,
     )
       .then((modules: Array<JsModule>) => {
         matchedModules.push(...modules);


### PR DESCRIPTION
We were using the wrong path to the current file when resolving a full path
to a relative alias (e.g. './index.scss'). By using the path provided
inside the config option, I was able to remove some duplication
(pathToCurrentFile being passed around in different forms).