### PR TITLE
Find exports defined through Object.defineProperty

### DIFF
--- a/lib/__tests__/findExports-test.js
+++ b/lib/__tests__/findExports-test.js
@@ -204,6 +204,31 @@ it('finds CommonJS exports defined later in the file', () => {
   });
 });
 
+it('finds exports defined through Object.defineProperty', () => {
+  expect(
+    findExports(
+      `
+    Object.defineProperty(exports, 'foo', {
+      enumerable: true,
+      get: function get() {
+        return 'foo';
+      }
+    });
+    const shadow = exports;
+    Object.defineProperty(shadow, 'bar', {
+      enumerable: true,
+      get: function get() {
+        return 'bar';
+      }
+    });
+  `,
+    ),
+  ).toEqual({
+    named: ['foo', 'bar'],
+    hasDefault: true,
+  });
+});
+
 it('finds CommonJS exports in a root, self-executing, function', () => {
   expect(
     findExports(

--- a/lib/findExports.js
+++ b/lib/findExports.js
@@ -58,6 +58,19 @@ function findCommonJSExports(
     // exports.use(foo);
     return [node.expression.arguments[0].name];
   }
+  if (
+    node.expression.type === 'CallExpression' &&
+    node.expression.callee.type === 'MemberExpression' &&
+    node.expression.callee.object.name === 'Object' &&
+    node.expression.callee.property.name === 'defineProperty' &&
+    node.expression.arguments.length > 1 &&
+    node.expression.arguments[0].type === 'Identifier' &&
+    aliasesForExports.has(node.expression.arguments[0].name) &&
+    node.expression.arguments[1].type === 'StringLiteral'
+  ) {
+    // Object.defineProperty(exports, 'foo', { ... });
+    return [node.expression.arguments[1].value];
+  }
   const { left, right } = node.expression;
   if (!left || !right) {
     return [];


### PR DESCRIPTION
I came across a package (graphql-relay) where import-js wouldn't find
any named exports, despite it having a few listed. Exports were defined
like this:

    Object.defineProperty(exports, 'foo', {
      enumerable: true,
      get: function get() {
        return 'foo';
      }
    });

While working on the fix, I made sure that we cover shadowed variables
for `exports` as well.