### PR TITLE
Improve "No project root found" error message, simplify project root check to only look for package.json

### DIFF
--- a/lib/__tests__/findProjectRoot-test.js
+++ b/lib/__tests__/findProjectRoot-test.js
@@ -25,7 +25,7 @@ it('treats package folders as roots', () => {
 
 it('throws if it can not find a folder', () => {
   expect(() => findProjectRoot('/foo/bar/baz.js')).toThrowError(
-    'No project root found',
+    'No project root found, looking for a directory with either a package.json file or a node_modules directory.',
   );
 });
 

--- a/lib/__tests__/findProjectRoot-test.js
+++ b/lib/__tests__/findProjectRoot-test.js
@@ -8,15 +8,13 @@ jest.mock('fs');
 afterEach(() => fs.__reset());
 
 it('finds the right folders', () => {
-  fs.__setFile('/foo/node_modules');
   fs.__setFile('/foo/package.json');
   fs.__setFile('/foo/bar/package.json');
-  expect(findProjectRoot('/foo/bar/baz.js')).toEqual('/foo');
+  expect(findProjectRoot('/foo/bar/baz.js')).toEqual('/foo/bar');
 });
 
 it('treats package folders as roots', () => {
-  // ...even if they don't have a nested node_modules folder
-  fs.__setFile('/foo/node_modules');
+  fs.__setFile('/foo/package.json');
   fs.__setFile('/foo/node_modules/bar/package.json');
   expect(findProjectRoot('/foo/node_modules/bar/baz/gaz.js')).toEqual(
     '/foo/node_modules/bar',
@@ -25,12 +23,11 @@ it('treats package folders as roots', () => {
 
 it('throws if it can not find a folder', () => {
   expect(() => findProjectRoot('/foo/bar/baz.js')).toThrowError(
-    'No project root found, looking for a directory with either a package.json file or a node_modules directory.',
+    'No project root found, looking for a directory with a package.json file.',
   );
 });
 
 it('works for relative paths as well', () => {
-  fs.__setFile(path.join(process.cwd(), 'foo/node_modules'));
   fs.__setFile(path.join(process.cwd(), 'foo/package.json'));
   expect(findProjectRoot('foo/bar/baz.js')).toEqual(
     path.join(process.cwd(), 'foo'),

--- a/lib/findProjectRoot.js
+++ b/lib/findProjectRoot.js
@@ -5,7 +5,7 @@ const NODE_MODULES_PATTERN = /\/node_modules$/;
 
 function findRecursive(directory) {
   if (directory === '/') {
-    throw new Error('No project root found');
+    throw new Error('No project root found, looking for a directory with either a package.json file or a node_modules directory.');
   }
   const pathToPackageJson = path.join(directory, 'package.json');
   const pathToNodeModulesFolder = path.join(directory, 'node_modules');

--- a/lib/findProjectRoot.js
+++ b/lib/findProjectRoot.js
@@ -1,23 +1,17 @@
 import fs from 'fs';
 import path from 'path';
 
-const NODE_MODULES_PATTERN = /\/node_modules$/;
-
 function findRecursive(directory) {
   if (directory === '/') {
-    throw new Error('No project root found, looking for a directory with either a package.json file or a node_modules directory.');
+    throw new Error('No project root found, looking for a directory with a package.json file.');
   }
+
   const pathToPackageJson = path.join(directory, 'package.json');
-  const pathToNodeModulesFolder = path.join(directory, 'node_modules');
-  const isPackageDependency = NODE_MODULES_PATTERN.test(
-    path.dirname(directory),
-  );
-  if (
-    fs.existsSync(pathToPackageJson) &&
-    (fs.existsSync(pathToNodeModulesFolder) || isPackageDependency)
-  ) {
+
+  if (fs.existsSync(pathToPackageJson)) {
     return directory;
   }
+
   return findRecursive(path.dirname(directory));
 }
 
@@ -25,6 +19,7 @@ function makeAbsolute(pathToFile) {
   if (pathToFile.startsWith('/')) {
     return pathToFile;
   }
+
   return path.join(process.cwd(), pathToFile);
 }
 


### PR DESCRIPTION
This error message is too vague and can be confusing for folks. We can
make it better by providing some more context.

More info: https://github.com/Galooshi/atom-import-js/issues/13

---

Stop checking for node_modules when finding project root

In https://github.com/Galooshi/import-js/pull/395 we discussed the logic
for determining that something is a project root. It seems that there
are situations where you might have a package.json file but no
node_modules directory (e.g. haven't run `npm install` yet, or there are
no dependencies). I think we can improve this by simplifying the check
to only look for package.json.

