### PR TITLE
Use path.isAbsolute for Windows compatibility

### DIFF
--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -148,7 +148,7 @@ export default class Importer {
             this.workingDirectory,
           );
           const results = this.results();
-          results.goto = filePath.startsWith('/')
+          results.goto = path.isAbsolute(filePath)
             ? filePath
             : path.join(this.workingDirectory, filePath);
           resolve(results);

--- a/lib/findProjectRoot.js
+++ b/lib/findProjectRoot.js
@@ -16,7 +16,7 @@ function findRecursive(directory) {
 }
 
 function makeAbsolute(pathToFile) {
-  if (pathToFile.startsWith('/')) {
+  if (path.isAbsolute(pathToFile)) {
     return pathToFile;
   }
 

--- a/lib/normalizePath.js
+++ b/lib/normalizePath.js
@@ -1,4 +1,5 @@
 // @flow
+import path from 'path';
 
 export default function normalizePath(
   rawPath: ?string,

--- a/lib/normalizePath.js
+++ b/lib/normalizePath.js
@@ -1,5 +1,4 @@
 // @flow
-import path from 'path';
 
 export default function normalizePath(
   rawPath: ?string,

--- a/lib/normalizePath.js
+++ b/lib/normalizePath.js
@@ -17,7 +17,7 @@ export default function normalizePath(
   }
 
   if (
-    rawPath === '.' || rawPath.startsWith('./') || rawPath.startsWith('../')
+    rawPath === '.' || rawPath.startsWith('./') || rawPath.startsWith('../') || path.isAbsolute(rawPath)
   ) {
     return rawPath;
   }

--- a/lib/normalizePath.js
+++ b/lib/normalizePath.js
@@ -18,7 +18,7 @@ export default function normalizePath(
   }
 
   if (
-    rawPath === '.' || rawPath.startsWith('./') || rawPath.startsWith('../') || path.isAbsolute(rawPath)
+    rawPath === '.' || rawPath.startsWith('./') || rawPath.startsWith('../')
   ) {
     return rawPath;
   }

--- a/lib/readFile.js
+++ b/lib/readFile.js
@@ -1,7 +1,8 @@
 import fs from 'fs';
+import path from 'path';
 
 export default function readFile(pathToFile) {
-  if (!pathToFile.startsWith('/')) {
+  if (!path.isAbsolute(pathToFile)) {
     return Promise.reject(new Error(`File path not absolue: ${pathToFile}`));
   }
   return new Promise((resolve, reject) => {

--- a/lib/requireResolve.js
+++ b/lib/requireResolve.js
@@ -1,11 +1,12 @@
 // @flow
+import path from 'path';
 
 /**
  * Thin wrapper around `require.resolve()` to avoid errors thrown, and to make
  * it easier to mock in tests.
  */
 export default function requireResolve(absolutePath: string): string {
-  if (!absolutePath.startsWith('/')) {
+  if (!path.isAbsolute(absolutePath)) {
     throw new Error(`Path must be absolute: ${absolutePath}`);
   }
   try {


### PR DESCRIPTION
Replaced `pathToFile.startsWith('/')` with `path.isAbsolute`

Closes #397