### PR TITLE
Fix indexing node_modules dependencies on Windows

### DIFF
--- a/lib/ModuleFinder.js
+++ b/lib/ModuleFinder.js
@@ -11,7 +11,7 @@ import readFile from './readFile';
 import requireResolve from './requireResolve';
 
 function assumedLocalPath(pathToResolvedPackageFile, packageName) {
-  const i = pathToResolvedPackageFile.indexOf(`/${packageName}/`);
+  const i = pathToResolvedPackageFile.indexOf(`${path.sep}${packageName}${path.sep}`);
   return `./node_modules/${pathToResolvedPackageFile.slice(i + 1)}`;
 }
 


### PR DESCRIPTION
We were assuming a forward slash here, but windows will use backslashes.
This, coupled with #398, will make import-js useful on windows machines
again.