### PR TITLE
Updates ModuleFinder for better symlink tracking.

### DIFF
--- a/lib/ModuleFinder.js
+++ b/lib/ModuleFinder.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import fs from 'fs';
 
 import winston from 'winston';
 
@@ -9,11 +10,6 @@ import findPackageDependencies from './findPackageDependencies';
 import lastUpdate from './lastUpdate';
 import readFile from './readFile';
 import requireResolve from './requireResolve';
-
-function assumedLocalPath(pathToResolvedPackageFile, packageName) {
-  const i = pathToResolvedPackageFile.indexOf(`${path.sep}${packageName}${path.sep}`);
-  return `./node_modules/${pathToResolvedPackageFile.slice(i + 1)}`;
-}
 
 /**
  * Checks for package.json or npm-shrinkwrap.json inside a list of files and
@@ -38,7 +34,56 @@ function expandFiles(files, workingDirectory) {
         return;
       }
 
-      const localPath = assumedLocalPath(resolvedPath, dep);
+      // Find the local path: that is, the resolved path relative to the local directory (taking
+      // into account any symlinks).
+      let localPath;
+      if (resolvedPath.indexOf(workingDirectory) === 0) {
+        // If the resolved path begins with the working directory, then it *is* the local path.
+        // (Just make it relative to the project root.)
+        localPath = `./${path.relative(workingDirectory, resolvedPath)}`;
+      } else {
+        // If it doesn't, we assume that pathToResolve is a symlink; we need to follow its target
+        // chain to the actual folder that we can tell what part of resolvedPath is within the
+        // package. For example, given a resolvedPath of "/Users/trotzig/foo/bar/baz/index.js", we
+        // need to know what part of that is within the package, so we can assemble the local path.
+        let resolvedDirectoryPath = pathToResolve;
+        let targetPath;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          // Follow the link.
+          try {
+            targetPath = fs.readlinkSync(resolvedDirectoryPath);
+          } catch (e) {
+            // readlinkSync throws "EINVAL" if the path is not a link; this means we've found the
+            // actual folder. (TODO: detect & re-throw if not this error.)
+            break;
+          }
+
+          if (path.isAbsolute(targetPath)) {
+            resolvedDirectoryPath = targetPath;
+          } else {
+            // If readlinkSync returns a relative path, it's relative to the link's *parent
+            // folder*, and we need to resolve it to an absolute path (with the extra '..' making
+            // up for the "link's parent folder" bit).
+            resolvedDirectoryPath = path.resolve(resolvedDirectoryPath, '..', targetPath);
+          }
+        }
+
+        // (Sanity check: make sure that we actually found an ancestor folder of resolvedPath.)
+        if (resolvedPath.indexOf(resolvedDirectoryPath) !== 0) {
+          throw new Error(
+            "expandFiles mismatch: package's resolved path and its local symlink target",
+          );
+        }
+
+        // With the link's full path, we can strip it from the beginning of resolvedPath.
+        const resolvedPathWithinDirectory = resolvedPath.slice(resolvedDirectoryPath.length);
+
+        // Then tack it on to the package path (pathToResolve), and get it relative to the cwd.
+        const absoluteLocalResolvedPath = path.join(pathToResolve, resolvedPathWithinDirectory);
+        // eslint-disable-next-line prefer-template
+        localPath = './' + path.relative(workingDirectory, absoluteLocalResolvedPath);
+      }
 
       promises.push(lastUpdate(localPath, workingDirectory).then(({ mtime }) =>
         Promise.resolve({


### PR DESCRIPTION
Currently it assumes that symlinked packages live in a folder named after the package, which is not always true or practical. Fixes #379.