### PR TITLE
Teaches findJsModulesFor about scoped packages.

### DIFF
--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -26,7 +26,10 @@ function findImportsFromEnvironment(
     );
 }
 
-const PACKAGE_NAME_PATTERN = /\.\/node_modules\/([^/]+)\//;
+// Given a string like './node_modules/package/foo/bar.baz', this is used to
+// extract 'package'. (Also matches scoped packages, for example finding
+// '@company/package' in './node_modules/@company/package/foo/bar.baz'.)
+const PACKAGE_NAME_PATTERN = /\.\/node_modules\/(?:@[^/]+\/)?([^/]+)\//;
 
 function findJsModulesFromModuleFinder(
   config: Configuration,


### PR DESCRIPTION
Currently it's unable to find packages like `@company/package`. Fixes #380.