### PR TITLE
Use require-relative to find paths to pkg dependencies

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -39,7 +39,7 @@ const DEFAULT_CONFIG = {
   cacheLocation: ({ config }: Object): string => {
     const hash = crypto
       .createHash('md5')
-      .update(config.workingDirectory)
+      .update(`${config.workingDirectory}-v2`)
       .digest('hex');
     return path.join(os.tmpdir(), `import-js-${hash}.db`);
   },

--- a/lib/ExportsStorage.js
+++ b/lib/ExportsStorage.js
@@ -246,7 +246,7 @@ export default class ExportsStorage {
   purgeDeadNodeModules(workingDirectory) {
     return new Promise((resolve, reject) => {
       this.db.all(
-        'SELECT path FROM mtimes WHERE (path LIKE "./node_modules/%")',
+        'SELECT path FROM mtimes WHERE (path LIKE "%/node_modules/%")',
         (err, files) => {
           if (err) {
             reject(err);

--- a/lib/ExportsStorage.js
+++ b/lib/ExportsStorage.js
@@ -40,7 +40,8 @@ export default class ExportsStorage {
             CREATE TABLE exports (
               name VARCHAR(100),
               isDefault INTEGER,
-              path TEXT
+              path TEXT,
+              packageName VARCHAR(100)
             )
           `,
           (err) => {
@@ -177,14 +178,15 @@ export default class ExportsStorage {
     });
   }
 
-  _insert({ name, pathToFile, isDefault }) {
+  _insert({ name, pathToFile, isDefault, packageName }) {
     const exportName = isDefault ? normalizedExportName(name) : name;
     return new Promise((resolve, reject) => {
       this.db.run(
-        'INSERT INTO exports (name, path, isDefault) VALUES (?, ?, ?)',
+        'INSERT INTO exports (name, path, isDefault, packageName) VALUES (?, ?, ?, ?)',
         exportName,
         pathToFile,
         isDefault,
+        packageName,
         (err) => {
           if (err) {
             reject(err);
@@ -196,14 +198,14 @@ export default class ExportsStorage {
     });
   }
 
-  update({ names, defaultNames, pathToFile, mtime }) {
+  update({ names, defaultNames, pathToFile, mtime, packageName }) {
     return this.remove(pathToFile).then(() =>
-      this.updateMtime(pathToFile, mtime).then(() => {
+      this.updateMtime(pathToFile, mtime, packageName).then(() => {
         const promises = names.map(name =>
-          this._insert({ name, pathToFile, isDefault: false }));
+          this._insert({ name, pathToFile, isDefault: false, packageName }));
         promises.push(
           ...defaultNames.map(name =>
-            this._insert({ name, pathToFile, isDefault: true })),
+            this._insert({ name, pathToFile, isDefault: true, packageName })),
         );
         return Promise.all(promises);
       }));
@@ -269,7 +271,7 @@ export default class ExportsStorage {
     return new Promise((resolve, reject) => {
       this.db.all(
         `
-          SELECT name, path, isDefault
+          SELECT name, path, isDefault, packageName
           FROM exports WHERE (
             (name = ? AND isDefault = 0) OR
             (name = ? AND isDefault = 1)
@@ -283,10 +285,11 @@ export default class ExportsStorage {
             return;
           }
           resolve(
-            rows.map(({ name, path, isDefault }) => ({
+            rows.map(({ name, path, isDefault, packageName }) => ({
               name,
               path,
               isDefault: !!isDefault,
+              packageName,
             })),
           );
         },

--- a/lib/ModuleFinder.js
+++ b/lib/ModuleFinder.js
@@ -1,5 +1,6 @@
 import path from 'path';
 
+import requireRelative from 'require-relative';
 import winston from 'winston';
 
 import ExportsStorage from './ExportsStorage';
@@ -8,12 +9,6 @@ import findExports from './findExports';
 import findPackageDependencies from './findPackageDependencies';
 import lastUpdate from './lastUpdate';
 import readFile from './readFile';
-import requireResolve from './requireResolve';
-
-function assumedLocalPath(pathToResolvedPackageFile, packageName) {
-  const i = pathToResolvedPackageFile.indexOf(`${path.sep}${packageName}${path.sep}`);
-  return `./node_modules/${pathToResolvedPackageFile.slice(i + 1)}`;
-}
 
 /**
  * Checks for package.json or npm-shrinkwrap.json inside a list of files and
@@ -29,20 +24,24 @@ function expandFiles(files, workingDirectory) {
       return;
     }
     findPackageDependencies(workingDirectory, true).forEach((dep) => {
-      const pathToResolve = path.join(workingDirectory, 'node_modules', dep);
-      const resolvedPath = requireResolve(pathToResolve);
-      if (resolvedPath === pathToResolve) {
-        // Getting back the same value as we sent in means that we couldn't
-        // resolve the dependency to a real file. Ignore this, as we won't be
-        // able to parse it anyway.
+      let resolvedPath;
+      try {
+        resolvedPath = path.relative(
+          workingDirectory,
+          requireRelative.resolve(dep, workingDirectory),
+        );
+        if (!resolvedPath.startsWith('.')) {
+          // path.relative won't add "./", but we need it further down the line
+          resolvedPath = `./${resolvedPath}`;
+        }
+      } catch (e) {
+        winston.error(`Failed to resolve "${dep}" relative to ${workingDirectory}`);
         return;
       }
 
-      const localPath = assumedLocalPath(resolvedPath, dep);
-
-      promises.push(lastUpdate(localPath, workingDirectory).then(({ mtime }) =>
+      promises.push(lastUpdate(resolvedPath, workingDirectory).then(({ mtime }) =>
         Promise.resolve({
-          path: localPath,
+          path: resolvedPath,
           mtime,
           alias: dep,
         })));

--- a/lib/ModuleFinder.js
+++ b/lib/ModuleFinder.js
@@ -43,7 +43,7 @@ function expandFiles(files, workingDirectory) {
         Promise.resolve({
           path: resolvedPath,
           mtime,
-          alias: dep,
+          packageName: dep,
         })));
     });
   });
@@ -143,7 +143,7 @@ export default class ModuleFinder {
       done();
       return;
     }
-    const { path: pathToFile, mtime, alias } = file;
+    const { path: pathToFile, mtime, packageName } = file;
     this.processingQueue = true;
     winston.debug(`Processing ${pathToFile}`);
     const fullPath = path.join(this.workingDirectory, pathToFile);
@@ -168,9 +168,9 @@ export default class ModuleFinder {
         }
         const defaultNames = [];
         if (exports.hasDefault) {
-          if (alias) {
+          if (packageName) {
             defaultNames.push(
-              ...aliasedExportNames(alias, this.ignorePackagePrefixes),
+              ...aliasedExportNames(packageName, this.ignorePackagePrefixes),
             );
           } else {
             defaultNames.push(...defaultExportNames(pathToFile));
@@ -182,6 +182,7 @@ export default class ModuleFinder {
             defaultNames,
             pathToFile,
             mtime,
+            packageName,
           })
           .then(() => {
             this.processQueue(done);

--- a/lib/__tests__/ExportsStorage-test.js
+++ b/lib/__tests__/ExportsStorage-test.js
@@ -112,7 +112,7 @@ it('can purge dead node_modules', (done) => {
     }),
     subject.update({
       names: [],
-      pathToFile: './node_modules/foo/index.js',
+      pathToFile: '../../node_modules/foo/index.js',
       defaultNames: ['Foo'],
       mtime: 1,
     }),

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -106,7 +106,7 @@ describe('Importer', () => {
               process.cwd(),
             ),
             mtime: Date.now(),
-            alias: dep,
+            packageName: dep,
           })),
         ))
         .then(() => {

--- a/lib/__tests__/ModuleFinder-test.js
+++ b/lib/__tests__/ModuleFinder-test.js
@@ -65,6 +65,7 @@ it('finds files', () => addFiles(['./foo/bar.js']).then(() =>
         path: './foo/bar.js',
         name: 'bar',
         isDefault: true,
+        packageName: null,
       },
     ]);
   })));
@@ -77,6 +78,7 @@ it('finds package dependencies', () => addFiles([
       path: './node_modules/pacman/index.js',
       name: 'pacman',
       isDefault: true,
+      packageName: 'pacman',
     },
   ]);
 })));
@@ -89,6 +91,7 @@ it('finds package dependencies not located in the local node_modules folder', ()
       path: '../../node_modules/hoisted/index.js',
       name: 'hoisted',
       isDefault: true,
+      packageName: 'hoisted',
     },
   ]);
 })));
@@ -101,6 +104,7 @@ it('can ignore package prefixes', () => addFiles([
       path: './node_modules/react-packer/index.js',
       name: 'packer',
       isDefault: true,
+      packageName: 'react-packer',
     },
   ]);
 })));
@@ -113,6 +117,7 @@ it('matches over the last folder name', () => addFiles([
       path: './Foo/bar.js',
       name: 'foobar',
       isDefault: true,
+      packageName: null,
     },
   ]);
 })));
@@ -125,6 +130,7 @@ it('knows about plural when matching over folder name', () => addFiles([
       path: './Foos/bar.js',
       name: 'foobar',
       isDefault: true,
+      packageName: null,
     },
   ]);
 })));

--- a/lib/__tests__/ModuleFinder-test.js
+++ b/lib/__tests__/ModuleFinder-test.js
@@ -1,15 +1,15 @@
 import path from 'path';
 
+import requireRelative from 'require-relative';
+
 import ModuleFinder from '../ModuleFinder';
 import findPackageDependencies from '../findPackageDependencies';
 import lastUpdate from '../lastUpdate';
 import normalizePath from '../normalizePath';
 import readFile from '../readFile';
-import requireResolve from '../requireResolve';
 
 jest.mock('../readFile');
 jest.mock('../findPackageDependencies');
-jest.mock('../requireResolve');
 jest.mock('../lastUpdate');
 
 let moduleFinder;
@@ -27,18 +27,22 @@ beforeEach(() => {
   readFile.mockImplementation(() => Promise.resolve('export default {}'));
 
   findPackageDependencies.mockImplementation(
-    () => new Set(['pacman', 'react-packer']),
+    () => new Set(['pacman', 'react-packer', 'hoisted']),
   );
 
-  requireResolve.__addResolvedPath(
-    path.join(process.cwd(), 'node_modules/pacman'),
-    path.join(process.cwd(), 'node_modules/pacman/index.js'),
-  );
-
-  requireResolve.__addResolvedPath(
-    path.join(process.cwd(), 'node_modules/react-packer'),
-    path.join(process.cwd(), 'node_modules/react-packer/index.js'),
-  );
+  requireRelative.resolve = jest.fn();
+  requireRelative.resolve.mockImplementation((moduleName) => {
+    switch (moduleName) {
+      case 'pacman' :
+        return path.join(process.cwd(), '/node_modules/pacman/index.js');
+      case 'react-packer' :
+        return path.join(process.cwd(), '/node_modules/react-packer/index.js');
+      case 'hoisted' :
+        return path.resolve(process.cwd(), '../../node_modules/hoisted/index.js');
+      default:
+        throw new Error(`Unknown dependency ${moduleName}`);
+    }
+  });
 
   lastUpdate.mockImplementation(pathToFile => Promise.resolve({
     path: pathToFile,
@@ -72,6 +76,18 @@ it('finds package dependencies', () => addFiles([
     {
       path: './node_modules/pacman/index.js',
       name: 'pacman',
+      isDefault: true,
+    },
+  ]);
+})));
+
+it('finds package dependencies not located in the local node_modules folder', () => addFiles([
+  './package.json',
+]).then(() => moduleFinder.find('hoisted').then((result) => {
+  expect(result).toEqual([
+    {
+      path: '../../node_modules/hoisted/index.js',
+      name: 'hoisted',
       isDefault: true,
     },
   ]);

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -26,8 +26,6 @@ function findImportsFromEnvironment(
     );
 }
 
-const PACKAGE_NAME_PATTERN = /\/node_modules\/([^/]+)\//;
-
 function findJsModulesFromModuleFinder(
   config: Configuration,
   normalizedName: string,
@@ -46,11 +44,9 @@ function findJsModulesFromModuleFinder(
       .find(normalizedName)
       .then((exports: Array<Object>) => {
         const modules = exports.map((
-          { path, isDefault }: Object,
+          { path, isDefault, packageName }: Object,
         ): ?JsModule => {
-          const match = path.match(PACKAGE_NAME_PATTERN);
-          if (match) {
-            const packageName = match[1];
+          if (packageName) {
             if (!isWantedPackageDependency(packageName)) {
               return undefined;
             }

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -26,7 +26,7 @@ function findImportsFromEnvironment(
     );
 }
 
-const PACKAGE_NAME_PATTERN = /\.\/node_modules\/([^/]+)\//;
+const PACKAGE_NAME_PATTERN = /\/node_modules\/([^/]+)\//;
 
 function findJsModulesFromModuleFinder(
   config: Configuration,
@@ -48,8 +48,9 @@ function findJsModulesFromModuleFinder(
         const modules = exports.map((
           { path, isDefault }: Object,
         ): ?JsModule => {
-          if (path.startsWith('./node_modules')) {
-            const packageName = path.match(PACKAGE_NAME_PATTERN)[1];
+          const match = path.match(PACKAGE_NAME_PATTERN);
+          if (match) {
+            const packageName = match[1];
             if (!isWantedPackageDependency(packageName)) {
               return undefined;
             }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lodash.sortby": "^4.2.2",
     "lodash.uniqby": "^4.2.1",
     "minimatch": "^3.0.0",
+    "require-relative": "^0.8.7",
     "semver": "^5.1.0",
     "sqlite3": "^3.1.8",
     "winston": "^2.3.1"


### PR DESCRIPTION
I'm working in a Lerna project where we hoist dependencies to the
project root. Before this change, import-js wouldn't find hoisted
packages. To fix this, I've included require-relative to find packages
relative to the current working directory.

https://github.com/kamicane/require-relative