### PR TITLE
Gracefully handle imports with local names for import

### DIFF
--- a/lib/ImportStatement.js
+++ b/lib/ImportStatement.js
@@ -33,7 +33,7 @@ export default class ImportStatement {
   defaultImport: ?string;
   hasSideEffects: boolean;
   importFunction: ?string;
-  namedImports: Array<string>;
+  namedImports: Array<Object>;
   originalImportString: ?string;
   path: string;
 
@@ -53,7 +53,7 @@ export default class ImportStatement {
       defaultImport?: ?string,
       hasSideEffects: boolean,
       importFunction?: ?string,
-      namedImports?: Array<string>,
+      namedImports?: Array<Object>,
       originalImportString?: ?string,
       path: string,
     } = {},
@@ -66,6 +66,17 @@ export default class ImportStatement {
     this.namedImports = namedImports;
     this.originalImportString = originalImportString;
     this.path = path;
+  }
+
+  hasVariable(variableName: string): boolean {
+    if (variableName === this.defaultImport) {
+      return true;
+    }
+    return !!this.namedImports.find(({
+      localName,
+    }: {
+      localName: string,
+    }): boolean => localName === variableName);
   }
 
   /**
@@ -81,7 +92,12 @@ export default class ImportStatement {
     }
 
     if (this.hasNamedImports()) {
-      const variableIndex = this.namedImports.indexOf(variableName);
+      const variableIndex = this.namedImports.findIndex(({
+        localName,
+      }: {
+        localName: String,
+      }): boolean =>
+        localName === variableName);
       if (variableIndex !== -1) {
         this.namedImports.splice(variableIndex, 1);
         touched = true;
@@ -125,7 +141,18 @@ export default class ImportStatement {
     if (!this.defaultImport && !this.hasNamedImports() && this.hasSideEffects) {
       return [this.path];
     }
-    return [this.defaultImport || '', ...(this.namedImports || [])];
+    return [this.defaultImport || '', ...this.localNames()];
+  }
+
+  localNames(): Array<string> {
+    if (!this.namedImports) {
+      return [];
+    }
+    return this.namedImports.map(({
+      localName,
+    }: {
+      localName: string
+    }): string => localName);
   }
 
   /**
@@ -133,7 +160,7 @@ export default class ImportStatement {
    *   imports.
    */
   variables(): Array<string> {
-    return [this.defaultImport, ...(this.namedImports || [])].filter(Boolean);
+    return [this.defaultImport, ...this.localNames()].filter(Boolean);
   }
 
   toImportStrings(maxLineLength: number, tab: string): Array<string> {
@@ -191,15 +218,30 @@ export default class ImportStatement {
       this.namedImports = this.namedImports || [];
       const originalNamedImports = this.namedImports.slice(0); // clone array
 
-      const importsSet = new Set(
-        [...this.namedImports, ...importStatement.namedImports].sort(),
-      );
+      let modified = false;
 
-      // TODO We should probably just use Sets for namedImports instead of
-      // converting back to arrays.
-      this.namedImports = Array.from(importsSet);
-
-      if (originalNamedImports !== this.namedImports) {
+      importStatement.namedImports.forEach((named: Object) => {
+        const namedImport = originalNamedImports.find(({
+          localName,
+        }: {
+          localName: string,
+        }): boolean =>
+          localName === named.localName);
+        if (!namedImport) {
+          this.namedImports.push(named);
+          modified = true;
+        }
+      });
+      if (modified) {
+        this.namedImports.sort((a: Object, b: Object): number => {
+          if (a.localName < b.localName) {
+            return -1;
+          }
+          if (a.localName > b.localName) {
+            return 1;
+          }
+          return 0;
+        });
         this._clearImportStringCache();
       }
     }
@@ -245,13 +287,26 @@ export default class ImportStatement {
       prefix = `${this.defaultImport}, `;
     }
 
-    const namedOneLine = `{ ${this.namedImports.join(', ')} }`;
+    const named = this.namedImports.map(({
+      localName,
+      importedName,
+    }: {
+      localName: string,
+      importedName: ?string,
+    }): string => {
+      if (!importedName) {
+        return localName;
+      }
+      return `${importedName} as ${localName}`;
+    });
+
+    const namedOneLine = `{ ${named.join(', ')} }`;
     const line = `${this.declarationKeyword || ''} ${prefix}${namedOneLine} ${equals} ${value}`;
     if (!isLineTooLong(line, maxLineLength)) {
       return line;
     }
 
-    const tabJoined = this.namedImports.join(`,\n${tab}`);
+    const tabJoined = named.join(`,\n${tab}`);
     const namedMultiLine = `{\n${tab}${tabJoined},\n}`;
     return `${this.declarationKeyword || ''} ${prefix}${namedMultiLine} ${equals} ${value}`;
   }

--- a/lib/ImportStatements.js
+++ b/lib/ImportStatements.js
@@ -146,6 +146,18 @@ export default class ImportStatements {
     });
   }
 
+  /**
+   * Method added to make it behave like an array.
+   */
+  find(callback: Function): ?ImportStatement {
+    const key = Object.keys(this.imports).find((key: string): boolean =>
+      callback(this.imports[key]));
+    if (!key) {
+      return undefined;
+    }
+    return this.imports[key];
+  }
+
   push(...importStatements: Array<ImportStatement>): ImportStatements {
     importStatements.forEach((importStatement: ImportStatement) => {
       const existingStatement = this.imports[importStatement.path];

--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -411,15 +411,9 @@ export default class Importer {
 
     // Look at the current imports and grab what is already imported for the
     // variable.
-    let matchingImportStatement;
-    this.findCurrentImports().imports.forEach((ist: ImportStatement) => {
-      if (
-        variableName === ist.defaultImport ||
-        (ist.namedImports && ist.namedImports.indexOf(variableName) !== -1)
-      ) {
-        matchingImportStatement = ist;
-      }
-    });
+    const matchingImportStatement =
+      this.findCurrentImports().imports.find((ist: ImportStatement): boolean =>
+        ist.hasVariable(variableName));
 
     if (!matchingImportStatement) {
       return undefined;
@@ -437,12 +431,7 @@ export default class Importer {
     // We couldn't resolve any module for the variable. As a fallback, we
     // can use the matching import statement. If that maps to a package
     // dependency, we will still open the right file.
-    let hasNamedExports = false;
-    if (matchingImportStatement.hasNamedImports()) {
-      hasNamedExports = matchingImportStatement.namedImports.indexOf(
-        variableName,
-      ) !== -1;
-    }
+    const hasNamedExports = matchingImportStatement.defaultImport !== variableName;
 
     const matchedModule = new JsModule({
       importPath: matchingImportStatement.path,

--- a/lib/JsModule.js
+++ b/lib/JsModule.js
@@ -159,7 +159,7 @@ export default class JsModule {
     let namedImports = [];
     let defaultImport = '';
     if (this.hasNamedExports) {
-      namedImports = [this.variableName];
+      namedImports = [{ localName: this.variableName }];
     } else {
       defaultImport = this.variableName;
     }

--- a/lib/__tests__/ImportStatement-test.js
+++ b/lib/__tests__/ImportStatement-test.js
@@ -19,12 +19,12 @@ describe('ImportStatement', () => {
     });
 
     it('is true with named imports', () => {
-      const statement = new ImportStatement({ namedImports: ['foo'] });
+      const statement = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
       expect(statement.hasNamedImports()).toBe(true);
     });
 
     it('is false when named imports are all removed', () => {
-      const statement = new ImportStatement({ namedImports: ['foo'] });
+      const statement = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
       statement.deleteVariable('foo');
       expect(statement.hasNamedImports()).toBe(false);
     });
@@ -37,7 +37,7 @@ describe('ImportStatement', () => {
         defaultImport: 'foo',
         hasSideEffects: false,
         originalImportString: "import foo, { bar } from './lib/foo';",
-        namedImports: ['bar'],
+        namedImports: [{ localName: 'bar' }],
         path: './lib/foo',
       });
       expect(statement.isParsedAndUntouched()).toBe(true);
@@ -51,7 +51,7 @@ describe('ImportStatement', () => {
           defaultImport: 'foo',
           hasSideEffects: false,
           originalImportString: "import foo, { bar } from './lib/foo';",
-          namedImports: ['bar'],
+          namedImports: [{ localName: 'bar' }],
           path: './lib/foo',
         });
         statement.deleteVariable('foo');
@@ -67,7 +67,7 @@ describe('ImportStatement', () => {
           defaultImport: 'foo',
           hasSideEffects: false,
           originalImportString: "import foo, { bar } from './lib/foo';",
-          namedImports: ['bar'],
+          namedImports: [{ localName: 'bar' }],
           path: './lib/foo',
         });
         statement.deleteVariable('bar');
@@ -81,7 +81,7 @@ describe('ImportStatement', () => {
         defaultImport: 'foo',
         hasSideEffects: false,
         originalImportString: "import foo, { bar } from './lib/foo';",
-        namedImports: ['bar'],
+        namedImports: [{ localName: 'bar' }],
         path: './lib/foo',
       });
       statement.deleteVariable('somethingElse');
@@ -107,12 +107,12 @@ describe('ImportStatement', () => {
     });
 
     it('is false with named imports', () => {
-      const statement = new ImportStatement({ namedImports: ['foo'] });
+      const statement = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
       expect(statement.isEmpty()).toBe(false);
     });
 
     it('is true when all named imports are removed', () => {
-      const statement = new ImportStatement({ namedImports: ['foo'] });
+      const statement = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
       statement.deleteVariable('foo');
       expect(statement.isEmpty()).toBe(true);
     });
@@ -136,7 +136,11 @@ describe('ImportStatement', () => {
 
     it('has named imports', () => {
       const statement = new ImportStatement({
-        namedImports: ['foo', 'bar', 'baz'],
+        namedImports: [
+          { localName: 'foo' },
+          { localName: 'bar' },
+          { localName: 'baz' },
+        ],
       });
 
       expect(statement.variables()).toEqual(['foo', 'bar', 'baz']);
@@ -145,7 +149,10 @@ describe('ImportStatement', () => {
     it('has default and named imports', () => {
       const statement = new ImportStatement({
         defaultImport: 'foo',
-        namedImports: ['bar', 'baz'],
+        namedImports: [
+          { localName: 'bar' },
+          { localName: 'baz' },
+        ],
       });
 
       expect(statement.variables()).toEqual(['foo', 'bar', 'baz']);
@@ -175,31 +182,34 @@ describe('ImportStatement', () => {
     });
 
     it('uses the existing named imports without a new named imports', () => {
-      const existing = new ImportStatement({ namedImports: ['foo'] });
+      const existing = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
       const newStatement = new ImportStatement();
       existing.merge(newStatement);
-      expect(existing.namedImports).toEqual(['foo']);
+      expect(existing.namedImports).toEqual([{ localName: 'foo' }]);
     });
 
     it('uses the new named imports without existing named imports', () => {
       const existing = new ImportStatement();
-      const newStatement = new ImportStatement({ namedImports: ['foo'] });
+      const newStatement = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
       existing.merge(newStatement);
-      expect(existing.namedImports).toEqual(['foo']);
+      expect(existing.namedImports).toEqual([{ localName: 'foo' }]);
     });
 
     it('merges the named imports when both existing and new ones exist', () => {
-      const existing = new ImportStatement({ namedImports: ['foo'] });
-      const newStatement = new ImportStatement({ namedImports: ['bar'] });
+      const existing = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
+      const newStatement = new ImportStatement({ namedImports: [{ localName: 'bar' }] });
       existing.merge(newStatement);
-      expect(existing.namedImports).toEqual(['bar', 'foo']);
+      expect(existing.namedImports).toEqual([
+        { localName: 'bar' },
+        { localName: 'foo' },
+      ]);
     });
 
     it('does not duplicate named imports', () => {
-      const existing = new ImportStatement({ namedImports: ['foo'] });
-      const newStatement = new ImportStatement({ namedImports: ['foo'] });
+      const existing = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
+      const newStatement = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
       existing.merge(newStatement);
-      expect(existing.namedImports).toEqual(['foo']);
+      expect(existing.namedImports).toEqual([{ localName: 'foo' }]);
     });
   });
 
@@ -270,7 +280,7 @@ describe('ImportStatement', () => {
       it('is ok with named imports', () => {
         const statement = new ImportStatement({
           declarationKeyword: 'import',
-          namedImports: ['foo', 'bar'],
+          namedImports: [{ localName: 'foo' }, { localName: 'bar' }],
           path: './lib/foo',
         });
         expect(statement.toImportStrings(80, '  ')).toEqual([
@@ -282,7 +292,13 @@ describe('ImportStatement', () => {
         const path = 'also_very_long_for_some_reason';
         const statement = new ImportStatement({
           declarationKeyword: 'import',
-          namedImports: ['foo', 'bar', 'baz', 'fizz', 'buzz'],
+          namedImports: [
+            { localName: 'foo' },
+            { localName: 'bar' },
+            { localName: 'baz' },
+            { localName: 'fizz' },
+            { localName: 'buzz' },
+          ],
           path,
         });
 
@@ -295,7 +311,7 @@ describe('ImportStatement', () => {
         const statement = new ImportStatement({
           declarationKeyword: 'import',
           defaultImport: 'foo',
-          namedImports: ['bar', 'baz'],
+          namedImports: [{ localName: 'bar' }, { localName: 'baz' }],
           path: './lib/foo',
         });
         expect(statement.toImportStrings(80, '  ')).toEqual([
@@ -308,7 +324,12 @@ describe('ImportStatement', () => {
         const statement = new ImportStatement({
           declarationKeyword: 'import',
           defaultImport: 'foo',
-          namedImports: ['bar', 'baz', 'fizz', 'buzz'],
+          namedImports: [
+            { localName: 'bar' },
+            { localName: 'baz' },
+            { localName: 'fizz' },
+            { localName: 'buzz' },
+          ],
           path,
         });
 
@@ -384,7 +405,7 @@ describe('ImportStatement', () => {
       it('is ok with named imports', () => {
         const statement = new ImportStatement({
           declarationKeyword: 'const',
-          namedImports: ['foo', 'bar'],
+          namedImports: [{ localName: 'foo' }, { localName: 'bar' }],
           path: './lib/foo',
         });
         expect(statement.toImportStrings(80, '  ')).toEqual([
@@ -395,7 +416,7 @@ describe('ImportStatement', () => {
       it('is ok with named imports and an importFunction', () => {
         const statement = new ImportStatement({
           declarationKeyword: 'const',
-          namedImports: ['foo', 'bar'],
+          namedImports: [{ localName: 'foo' }, { localName: 'bar' }],
           path: './lib/foo',
           importFunction: 'myCustomRequire',
         });
@@ -420,7 +441,13 @@ describe('ImportStatement', () => {
         const path = 'also_very_long_for_some_reason';
         const statement = new ImportStatement({
           declarationKeyword: 'const',
-          namedImports: ['foo', 'bar', 'baz', 'fizz', 'buzz'],
+          namedImports: [
+            { localName: 'foo' },
+            { localName: 'bar' },
+            { localName: 'baz' },
+            { localName: 'fizz' },
+            { localName: 'buzz' },
+          ],
           path,
         });
 
@@ -433,7 +460,7 @@ describe('ImportStatement', () => {
         const statement = new ImportStatement({
           declarationKeyword: 'const',
           defaultImport: 'foo',
-          namedImports: ['bar', 'baz'],
+          namedImports: [{ localName: 'bar' }, { localName: 'baz' }],
           path: './lib/foo',
         });
         expect(statement.toImportStrings(80, '  ')).toEqual([
@@ -448,7 +475,7 @@ describe('ImportStatement', () => {
           const statement = new ImportStatement({
             declarationKeyword: 'const',
             defaultImport: 'foo',
-            namedImports: ['bar', 'baz'],
+            namedImports: [{ localName: 'bar' }, { localName: 'baz' }],
             path: './lib/foo',
             importFunction: 'myCustomRequire',
           });
@@ -464,7 +491,12 @@ describe('ImportStatement', () => {
         const statement = new ImportStatement({
           declarationKeyword: 'const',
           defaultImport: 'foo',
-          namedImports: ['bar', 'baz', 'fizz', 'buzz'],
+          namedImports: [
+            { localName: 'bar' },
+            { localName: 'baz' },
+            { localName: 'fizz' },
+            { localName: 'buzz' },
+          ],
           path,
         });
 

--- a/lib/__tests__/ImportStatements-test.js
+++ b/lib/__tests__/ImportStatements-test.js
@@ -359,6 +359,26 @@ describe('ImportStatements', () => {
     );
 
     it(
+      'does not alter local names for named imports',
+      () => {
+        const statements = prepare(
+          `
+        import foo, { bar as far } from './lib/foo'
+      `,
+        );
+        statements.deleteVariables(['foo']);
+
+        expect(statements.toArray()).toEqual([
+          "import { bar as far } from './lib/foo';",
+        ]);
+
+        statements.deleteVariables(['far']);
+
+        expect(statements.toArray()).toEqual([]);
+      },
+    );
+
+    it(
       'removes empty statements when deleting default and named imports',
       () => {
         const statements = prepare(

--- a/lib/__tests__/findCurrentImports-test.js
+++ b/lib/__tests__/findCurrentImports-test.js
@@ -60,6 +60,46 @@ module.exports = AlignmentRibbonPage;
   expect(imports.range.end).toEqual(1);
 });
 
+it('finds deconstructed import statements', () => {
+  const currentFileContent = `
+import { foo, bar } from 'far';
+  `.trim();
+
+  const imports = findCurrentImports(
+    new Configuration('./foo.js'),
+    currentFileContent,
+    parse(currentFileContent),
+  );
+  expect(imports.imports.size()).toEqual(1);
+  imports.imports.forEach((imp) => {
+    expect(imp.path).toEqual('far');
+    expect(imp.declarationKeyword).toEqual('import');
+    expect(imp.namedImports).toEqual([{ localName: 'foo' }, { localName: 'bar' }]);
+  });
+  expect(imports.range.start).toEqual(0);
+  expect(imports.range.end).toEqual(1);
+});
+
+it('finds deconstructed require statements', () => {
+  const currentFileContent = `
+const { foo, bar } = require('far');
+  `.trim();
+
+  const imports = findCurrentImports(
+    new Configuration('./foo.js'),
+    currentFileContent,
+    parse(currentFileContent),
+  );
+  expect(imports.imports.size()).toEqual(1);
+  imports.imports.forEach((imp) => {
+    expect(imp.path).toEqual('far');
+    expect(imp.declarationKeyword).toEqual('const');
+    expect(imp.namedImports).toEqual([{ localName: 'foo' }, { localName: 'bar' }]);
+  });
+  expect(imports.range.start).toEqual(0);
+  expect(imports.range.end).toEqual(1);
+});
+
 it('finds namespace imports', () => {
   const currentFileContent = `
 import * as api from './api'

--- a/lib/findCurrentImports.js
+++ b/lib/findCurrentImports.js
@@ -17,11 +17,17 @@ function convertToImportStatement(node: Object): ?ImportStatement {
       defaultImport: defaultSpecifier ? defaultSpecifier.local.name : undefined,
       hasSideEffects: node.specifiers.length === 0,
       namedImports: node.specifiers
-        .map((spec: Object): ?Array<string> => {
+        .map((spec: Object): ?Object => {
           if (spec.type !== 'ImportSpecifier') {
             return undefined;
           }
-          return spec.local.name;
+          if (spec.local.name !== spec.imported.name) {
+            return {
+              localName: spec.local.name,
+              importedName: spec.imported.name,
+            };
+          }
+          return { localName: spec.local.name };
         })
         .filter(Boolean),
       path: node.source.value,
@@ -74,7 +80,9 @@ function convertToImportStatement(node: Object): ?ImportStatement {
       : undefined;
 
     const namedImports = declaration.id.type === 'ObjectPattern'
-      ? declaration.id.properties.map((p: Object): String => p.value.name)
+      ? declaration.id.properties.map((p: Object): Object => ({
+        localName: p.value.name,
+      }))
       : undefined;
 
     return new ImportStatement({


### PR DESCRIPTION
Import-js never produces import statements with local names to named
imports, e.g.

  import { foo as bar } from 'car';

But there's no guarantee that the file is free from them, so we need to
handle them gracefully. I did that by making the `namedImports` array
contain objects with the local and (optionally) imported name. On import
statement production, we then use the imported name if we need to.

Fixes #407