### PR TITLE
Find nested exports when inside ternary

### DIFF
--- a/lib/__tests__/findExports-test.js
+++ b/lib/__tests__/findExports-test.js
@@ -259,26 +259,6 @@ it('finds CommonJS exports in a root, self-executing, function', () => {
   });
 });
 
-it('follows exported requires', () => {
-  fs.__setFile(
-    '/path/to/foo.js',
-    'const Result = { bar: 123 }; module.exports = Result;',
-    { isDirectory: () => false },
-  );
-  requireRelative.resolve.mockImplementation(() => '/path/to/foo.js');
-  expect(
-    findExports(
-      `
-    module.exports = require('./foo');
-  `,
-      '/path/to/file.js',
-    ),
-  ).toEqual({
-    named: ['bar'],
-    hasDefault: true,
-  });
-});
-
 it('finds inner CommonJS exports', () => {
   // this is from logpath
   expect(
@@ -457,5 +437,27 @@ it('does not fail for inner exports that are not objects', () => {
   ).toEqual({
     named: [],
     hasDefault: true,
+  });
+});
+
+describe('recursive exports', () => {
+  it('follows exported requires', () => {
+    fs.__setFile(
+      '/path/to/foo.js',
+      'const Result = { bar: 123 }; module.exports = Result;',
+      { isDirectory: () => false },
+    );
+    requireRelative.resolve.mockImplementation(() => '/path/to/foo.js');
+    expect(
+      findExports(
+        `
+      module.exports = require('./foo');
+    `,
+        '/path/to/file.js',
+      ),
+    ).toEqual({
+      named: ['bar'],
+      hasDefault: true,
+    });
   });
 });

--- a/lib/__tests__/findExports-test.js
+++ b/lib/__tests__/findExports-test.js
@@ -441,18 +441,31 @@ it('does not fail for inner exports that are not objects', () => {
 });
 
 describe('recursive exports', () => {
-  it('follows exported requires', () => {
+  beforeEach(() => {
     fs.__setFile(
       '/path/to/foo.js',
       'const Result = { bar: 123 }; module.exports = Result;',
       { isDirectory: () => false },
     );
     requireRelative.resolve.mockImplementation(() => '/path/to/foo.js');
+  });
+
+  it('follows exported requires', () => {
+    expect(
+      findExports("module.exports = require('./foo');", '/path/to/file.js'),
+    ).toEqual({
+      named: ['bar'],
+      hasDefault: true,
+    });
+  });
+
+  it('picks the first require if inside a ternary', () => {
     expect(
       findExports(
-        `
-      module.exports = require('./foo');
-    `,
+      `
+        module.exports = process.env.NODE_ENV === 'test' ?
+          require('./foo') : require('./ignored');
+      `,
         '/path/to/file.js',
       ),
     ).toEqual({

--- a/lib/findExports.js
+++ b/lib/findExports.js
@@ -38,6 +38,11 @@ function findESNamedExports(node) {
 }
 
 function resolveNestedNamedExports(node, absolutePathToFile) {
+  if (node.type === 'ConditionalExpression') {
+    // Potential ternary-style export - we pick the first one
+    // module.exports = foo ? require('a') : require('b');
+    return resolveNestedNamedExports(node.consequent, absolutePathToFile);
+  }
   if (
     node.type === 'CallExpression' &&
     node.callee.name === 'require' &&

--- a/lib/findExports.js
+++ b/lib/findExports.js
@@ -37,6 +37,26 @@ function findESNamedExports(node) {
   return result;
 }
 
+function resolveNestedNamedExports(node, absolutePathToFile) {
+  if (
+    node.type === 'CallExpression' &&
+    node.callee.name === 'require' &&
+    node.arguments.length === 1 &&
+    node.arguments[0].type === 'StringLiteral'
+  ) {
+    // module.exports = require('someOtherFile.js');
+    const pathToRequiredFile = requireRelative.resolve(
+      node.arguments[0].value,
+      path.dirname(absolutePathToFile));
+
+    const requiredFileContent = fs.readFileSync(pathToRequiredFile, 'utf8');
+    // eslint-disable-next-line no-use-before-define
+    const { named } = findExports(requiredFileContent, pathToRequiredFile);
+    return named;
+  }
+  return undefined;
+}
+
 function findCommonJSExports(
   node,
   {
@@ -82,21 +102,9 @@ function findCommonJSExports(
       left.property.name === 'exports') ||
     aliasesForExports.has(left.name)
   ) {
-    if (
-      right.type === 'CallExpression' &&
-      right.callee.name === 'require' &&
-      right.arguments.length === 1 &&
-      right.arguments[0].type === 'StringLiteral'
-    ) {
-      // module.exports = require('someOtherFile.js');
-      const pathToRequiredFile = requireRelative.resolve(
-        right.arguments[0].value,
-        path.dirname(absolutePathToFile));
-
-      const requiredFileContent = fs.readFileSync(pathToRequiredFile, 'utf8');
-      // eslint-disable-next-line no-use-before-define
-      const { named } = findExports(requiredFileContent, pathToRequiredFile);
-      return named;
+    const nestedNamed = resolveNestedNamedExports(right, absolutePathToFile);
+    if (nestedNamed) {
+      return nestedNamed;
     }
     // module.exports = { foo: 'foo' };
     if (right.type === 'ObjectExpression') {


### PR DESCRIPTION
Some libraries (like [airbnb-prop-types](https://unpkg.com/airbnb-prop-types@2.5.4)), like to export different
files depending the current NODE_ENV. Export statements can then look
something like:

```js
  module.exports = process.env.NODE_ENV === 'production' ?
    require('a') : require('b');
```

In most cases, the two alternatives will have the same structure, so
finding named exports in either of the two should be fine.

I've made it so that we always pick the first alternative (the
`consequent`) in ternary exports.

There are of course other ways of conditionally exporting things. For
now I'm only dealing with ternaries, we can worry about other styles
when we have those use-cases.

Fixes #411
