### PR TITLE
Include import statement in list of unresolved imports

### DIFF
--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -410,6 +410,9 @@ export default class Importer {
         this.pathToCurrentFile,
         this.workingDirectory,
       ),
+      importStatement: jsModule
+        .toImportStatement(this.config)
+        .toImportStrings(Infinity, '  ')[0],
     }));
 
     return undefined;

--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -404,15 +404,14 @@ export default class Importer {
     this.unresolvedImports[variableName] = jsModules.map((
       jsModule: JsModule,
     ): Object => ({
-      displayName: jsModule.displayName(),
+      displayName: jsModule
+        .toImportStatement(this.config)
+        .toImportStrings(Infinity, '  ')[0],
       importPath: jsModule.importPath,
       filePath: jsModule.resolvedFilePath(
         this.pathToCurrentFile,
         this.workingDirectory,
       ),
-      importStatement: jsModule
-        .toImportStatement(this.config)
-        .toImportStrings(Infinity, '  ')[0],
     }));
 
     return undefined;

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -942,16 +942,19 @@ foo
                 displayName: './bar/foo',
                 filePath: './bar/foo.jsx',
                 importPath: './bar/foo',
+                importStatement: "import foo from './bar/foo';",
               },
               {
                 displayName: './zoo/foo',
                 filePath: './zoo/foo.js',
                 importPath: './zoo/foo',
+                importStatement: "import foo from './zoo/foo';",
               },
               {
                 displayName: './zoo/goo/Foo (main: index.js)',
                 filePath: 'zoo/goo/Foo/index.js',
                 importPath: './zoo/goo/Foo',
+                importStatement: "import foo from './zoo/goo/Foo';",
               },
             ],
           });

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -939,22 +939,19 @@ foo
           expect(result.unresolvedImports).toEqual({
             foo: [
               {
-                displayName: './bar/foo',
+                displayName: "import foo from './bar/foo';",
                 filePath: './bar/foo.jsx',
                 importPath: './bar/foo',
-                importStatement: "import foo from './bar/foo';",
               },
               {
-                displayName: './zoo/foo',
+                displayName: "import foo from './zoo/foo';",
                 filePath: './zoo/foo.js',
                 importPath: './zoo/foo',
-                importStatement: "import foo from './zoo/foo';",
               },
               {
-                displayName: './zoo/goo/Foo (main: index.js)',
+                displayName: "import foo from './zoo/goo/Foo';",
                 filePath: 'zoo/goo/Foo/index.js',
                 importPath: './zoo/goo/Foo',
-                importStatement: "import foo from './zoo/goo/Foo';",
               },
             ],
           });


### PR DESCRIPTION
Adds support for #422

Presumably there will always be exactly one import string for the unresolved imports use case, so it's accurate to access it as [0]. And there will never be a multiline import string, so the tab string isn't used. But happy to change the implementation.