### PR TITLE
Sort unresolved imports by path distance to the current file

### DIFF
--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -401,6 +401,11 @@ export default class Importer {
       return undefined;
     }
 
+    const distanceToCurrentFile = (importPath: string): number => {
+      const match = path.relative(this.pathToCurrentFile, importPath).match(/\//g);
+      return match ? match.length : 0;
+    };
+
     this.unresolvedImports[variableName] = jsModules.map((
       jsModule: JsModule,
     ): Object => ({
@@ -412,7 +417,8 @@ export default class Importer {
         this.pathToCurrentFile,
         this.workingDirectory,
       ),
-    }));
+    })).sort((a: JsModule, b: JsModule): number =>
+      distanceToCurrentFile(a.importPath) - distanceToCurrentFile(b.importPath));
 
     return undefined;
   }

--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -401,9 +401,9 @@ export default class Importer {
       return undefined;
     }
 
-    const distanceToCurrentFile = (importPath: string): number => {
-      const match = path.relative(this.pathToCurrentFile, importPath).match(/\//g);
-      return match ? match.length : 0;
+    const countSeparators = (importPath: string): number => {
+      const separators = importPath.match(/\//g);
+      return separators ? separators.length : 0;
     };
 
     this.unresolvedImports[variableName] = jsModules.map((
@@ -418,7 +418,7 @@ export default class Importer {
         this.workingDirectory,
       ),
     })).sort((a: JsModule, b: JsModule): number =>
-      distanceToCurrentFile(a.importPath) - distanceToCurrentFile(b.importPath));
+      countSeparators(a.importPath) - countSeparators(b.importPath));
 
     return undefined;
   }

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -957,6 +957,30 @@ foo
           });
         });
       });
+
+      describe('when multiple files resolve the variable', () => {
+        beforeEach(() => {
+          existingFiles = ['zoo/goo/Foo/index.js', 'bar/foo.jsx'];
+        });
+
+        it('sorts the results', () => {
+          subject();
+          expect(result.unresolvedImports).toEqual({
+            foo: [
+              {
+                displayName: "import foo from './bar/foo';",
+                filePath: './bar/foo.jsx',
+                importPath: './bar/foo',
+              },
+              {
+                displayName: "import foo from './zoo/goo/Foo';",
+                filePath: 'zoo/goo/Foo/index.js',
+                importPath: './zoo/goo/Foo',
+              },
+            ],
+          });
+        });
+      });
     });
 
     describe('importing a module with a package.json file', () => {


### PR DESCRIPTION
Uses the simple heuristic of path distance to rank imports.

Closer paths are frequently the right ones: probably from `./a.js` you're looking for `./foo.js` rather than `./something/very/deeply/nested/foo.js` or `../../../../foo.js`.

node_modules will have an `importPath` like `react`, so they will generally come before deeply nested imports (though there could be cases where they don't).

I'm sure there are better ranking algorithms but this one is pretty straightforward works reasonably well for me 😄 