### PR TITLE
Moved checking for excludes to allow excluding node_modules

### DIFF
--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -709,6 +709,24 @@ fooBar
             subject();
             expect(result.messages).toEqual(['Imported `foo-bar`']);
           });
+
+          describe('when there is an exclude', () => {
+            beforeEach(() => {
+              configuration.excludes = ['./node_modules/foo-bar/*'];
+            });
+
+            afterEach(() => {
+              configuration.excludes = [];
+            });
+
+            it('excludes the import', () => {
+              expect(subject()).toEqual(
+                `
+fooBar
+            `.trim(),
+              );
+            });
+          });
         },
       );
 

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -50,6 +50,12 @@ function findJsModulesFromModuleFinder(
         const modules = exports.map((
           { name, path, isDefault, packageName }: Object,
         ): ?JsModule => {
+          // Filter out modules that are in the `excludes` config.
+          if (config.get('excludes').some((glob: string): boolean =>
+            minimatch(path, glob))) {
+            return undefined;
+          }
+
           if (packageName) {
             if (!isWantedPackageDependency(packageName)) {
               return undefined;
@@ -59,12 +65,6 @@ function findJsModulesFromModuleFinder(
               variableName: isSearch ? name : variableName,
               hasNamedExports: !isDefault,
             });
-          }
-
-          // Filter out modules that are in the `excludes` config.
-          if (config.get('excludes').some((glob: string): boolean =>
-            minimatch(path, glob))) {
-            return undefined;
           }
 
           return JsModule.construct({


### PR DESCRIPTION
We can now exclude specific node_modules using `excludes`