### PR TITLE
Configure Babylon to understand dynamic imports

### DIFF
--- a/lib/__tests__/parse-test.js
+++ b/lib/__tests__/parse-test.js
@@ -4,7 +4,7 @@ it('knows about object rest spread', () => {
   expect(() => parse(
     `
     const { a, b, ...c } = foo;
-  `,
+    `,
   )).not.toThrowError();
 });
 
@@ -13,7 +13,7 @@ it('knows about decorators', () => {
     `
     @Awesome
     class Foo {};
-  `,
+    `,
   )).not.toThrowError();
 });
 
@@ -23,6 +23,14 @@ it('knows about class properties', () => {
     class Foo {
       foo = 'bar';
     }
-  `,
+    `,
+  )).not.toThrowError();
+});
+
+it('knows about dynamic imports', () => {
+  expect(() => parse(
+    `
+    import('./foo').then(module => module());
+    `,
   )).not.toThrowError();
 });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -11,6 +11,7 @@ export default function parse(fileContent: String): Object {
       'objectRestSpread',
       'decorators',
       'classProperties',
+      'dynamicImport',
     ],
     sourceType: 'module',
   });

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "babel-eslint": "^7.1.1",
-    "babel-jest": "^19.0.0",
+    "babel-jest": "^20.0.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",


### PR DESCRIPTION
Now that dynamic imports are a stage 3 proposal [0], more people are
going to start using this syntax and we should support it out of the
box. Without this plugin, import-js will crash when run on a file that
uses this syntax.

[0]: https://github.com/tc39/proposal-dynamic-import

We may eventually want to expose the array of Babylon plugins so they
can be configured by the end user, but I think we should wait to do that
until we actually see the need for it.

Addresses #428