### PR TITLE
Add Node 7 and 8 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - "4"
   - "5"
   - "6"
+  - "7"
+  - "8"
 
 before_script:
   - npm install -g codeclimate-test-reporter


### PR DESCRIPTION
We want to ensure that import-js continues to work on these versions of
Node.