### PR TITLE
Add sortImports option to enable/disable import sorting

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -60,6 +60,7 @@ const DEFAULT_CONFIG = {
   minimumVersion: '0.0.0',
   moduleNameFormatter: ({ moduleName }: Object): string => moduleName,
   moduleSideEffectImports: (): Array<string> => [],
+  sortImports: true,
   stripFileExtensions: ['.js', '.jsx'],
   tab: '  ',
   useRelativePaths: true,

--- a/lib/ImportStatements.js
+++ b/lib/ImportStatements.js
@@ -248,8 +248,11 @@ export default class ImportStatements {
         !importStatement.isParsedAndUntouched(),
     );
     result = flattenDeep(result);
-    result = sortBy(result, (is: ImportStatement): Array<string> =>
-      is.toNormalized());
+
+    if (this.config.get('sortImports')) {
+      result = sortBy(result, (is: ImportStatement): Array<string> => is.toNormalized());
+    }
+
     result = uniqBy(result, (is: ImportStatement): Array<string> =>
       is.toNormalized());
 

--- a/lib/__tests__/ImportStatements-test.js
+++ b/lib/__tests__/ImportStatements-test.js
@@ -303,6 +303,28 @@ describe('ImportStatements', () => {
     });
   });
 
+  describe('when sortImports is false', () => {
+    beforeEach(() => {
+      FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+        sortImports: false,
+      });
+    });
+
+    it('does not sort statements', () => {
+      const statements = prepare(
+        `
+        import foo from 'foo';
+        import bar from 'bar';
+      `,
+      );
+
+      expect(statements.toArray()).toEqual([
+        "import foo from 'foo';",
+        "import bar from 'bar';",
+      ]);
+    });
+  });
+
   describe('.deleteVariables()', () => {
     it('removes empty import statements when deleting default imports', () => {
       const statements = prepare(


### PR DESCRIPTION
I've added a config option to disable sorting, per https://github.com/Galooshi/import-js/issues/284