### PR TITLE
Preserve comments and whitespace

### DIFF
--- a/lib/ImportStatement.js
+++ b/lib/ImportStatement.js
@@ -35,6 +35,7 @@ export default class ImportStatement {
   importFunction: ?string;
   namedImports: Array<Object>;
   originalImportString: ?string;
+  leadingContent: ?string;
   path: string;
 
   constructor(
@@ -46,6 +47,7 @@ export default class ImportStatement {
       importFunction,
       namedImports = [],
       originalImportString,
+      leadingContent,
       path,
     }: {
       assignment?: ?string,
@@ -55,6 +57,7 @@ export default class ImportStatement {
       importFunction?: ?string,
       namedImports?: Array<Object>,
       originalImportString?: ?string,
+      leadingContent?: ?string,
       path: string,
     } = {},
   ) {
@@ -65,6 +68,7 @@ export default class ImportStatement {
     this.importFunction = importFunction;
     this.namedImports = namedImports;
     this.originalImportString = originalImportString;
+    this.leadingContent = leadingContent;
     this.path = path;
   }
 
@@ -164,6 +168,16 @@ export default class ImportStatement {
   }
 
   toImportStrings(maxLineLength: number, tab: string): Array<string> {
+    const strings = this._importStrings(maxLineLength, tab);
+
+    if (this.leadingContent && strings.length > 0) {
+      strings[0] = this.leadingContent + strings[0];
+    }
+
+    return strings;
+  }
+
+  _importStrings(maxLineLength: number, tab: string): Array<string> {
     if (this.originalImportString) {
       return [this.originalImportString];
     }

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -512,6 +512,159 @@ foo
         },
       );
 
+      describe('when sorting and grouping are disabled', () => {
+        beforeEach(() => {
+          configuration.groupImports = false;
+          configuration.sortImports = false;
+        });
+
+        it('leaves newlines', () => {
+          text = `
+import bar from './bar';
+
+import baz from './bar/baz';
+
+foo
+          `.trim();
+
+          expect(subject()).toEqual(
+            `
+import foo from './bar/foo';
+import bar from './bar';
+
+import baz from './bar/baz';
+
+foo
+          `.trim(),
+          );
+        });
+
+        it('leaves single-line comments', () => {
+          text = `
+import bar from './bar';
+
+// Comment
+import baz from './bar/baz';
+
+foo
+          `.trim();
+
+          expect(subject()).toEqual(
+            `
+import foo from './bar/foo';
+import bar from './bar';
+
+// Comment
+import baz from './bar/baz';
+
+foo
+          `.trim(),
+          );
+        });
+
+        it('leaves content before imports', () => {
+          text = `
+'use strict';
+// Comment A
+
+// Comment B
+import bar from './bar';
+import baz from './bar/baz';
+
+foo
+          `.trim();
+
+          expect(subject()).toEqual(
+            `
+'use strict';
+// Comment A
+
+// Comment B
+import foo from './bar/foo';
+import bar from './bar';
+import baz from './bar/baz';
+
+foo
+          `.trim(),
+          );
+        });
+
+        it('leaves multiple single-line comments', () => {
+          text = `
+import bar from './bar';
+
+// Comment A
+// Comment B
+import baz from './bar/baz';
+
+foo
+          `.trim();
+
+          expect(subject()).toEqual(
+            `
+import foo from './bar/foo';
+import bar from './bar';
+
+// Comment A
+// Comment B
+import baz from './bar/baz';
+
+foo
+          `.trim(),
+          );
+        });
+
+        it('leaves 1-line multi-line comments', () => {
+          text = `
+import bar from './bar';
+
+/* Comment */
+import baz from './bar/baz';
+
+foo
+          `.trim();
+
+          expect(subject()).toEqual(
+            `
+import foo from './bar/foo';
+import bar from './bar';
+
+/* Comment */
+import baz from './bar/baz';
+
+foo
+          `.trim(),
+          );
+        });
+
+        it('leaves n-line multi-line comments', () => {
+          text = `
+import bar from './bar';
+
+/* Comment
+ * 123
+ */
+import baz from './bar/baz';
+
+foo
+          `.trim();
+
+          expect(subject()).toEqual(
+            `
+import foo from './bar/foo';
+import bar from './bar';
+
+/* Comment
+ * 123
+ */
+import baz from './bar/baz';
+
+foo
+          `.trim(),
+          );
+        });
+      });
+
       describe('when the variable name matches last folder+filename', () => {
         beforeEach(() => {
           existingFiles = ['sko/bar/foo.jsx'];

--- a/lib/findCurrentImports.js
+++ b/lib/findCurrentImports.js
@@ -111,7 +111,7 @@ export default function findCurrentImports(
   };
 
   let done = false;
-  ast.program.body.forEach((node: Object) => {
+  ast.program.body.forEach((node: Object, index: number) => {
     if (done) {
       return;
     }
@@ -122,6 +122,29 @@ export default function findCurrentImports(
       // We've reached the end of the imports block
       done = true;
       return;
+    }
+
+    // If groupImports and sortImports are both disabled, we will preserve
+    // whitespace and comments, in order to reduce changes made by `fix`.
+    // We save leading content for all imports, except the first one.
+    if (
+      !result.imports.empty() &&
+      !config.get('groupImports') &&
+      !config.get('sortImports') &&
+      index > 0
+    ) {
+      let previousNodeEnd = ast.program.body[index - 1].end;
+
+      // Advance past the end of the line
+      const newlineIndex = currentFileContent.indexOf('\n', previousNodeEnd);
+      if (newlineIndex !== -1) {
+        previousNodeEnd += (newlineIndex - previousNodeEnd) + 1;
+      }
+
+      importStatement.leadingContent = currentFileContent.slice(
+        previousNodeEnd,
+        node.start,
+      );
     }
 
     importStatement.originalImportString = currentFileContent.slice(


### PR DESCRIPTION
This is a rough first pass. 

I want to preserve comments (https://github.com/Galooshi/import-js/issues/215) so that we can `fix` imports without losing things like eslint line rules, manually added labels for groups of imports, etc. I think it would be hard to perfectly capture every use case with the same setting, so there might need to be multiple settings. 

By far the most common kind of comment/whitespace within imports in our codebase is a comment directly before an import, optionally with a newline above it:

```
import foo from 'foo'

// Comment
import bar from 'bar'
```

The behavior I chose is: an import can have "leading content", which will follow the import if it moves. In this example, the newline and comment would follow `import bar` if it's moved. If sorting is disabled, this means comments and whitespace will remain exactly as they are, with new imports added on top.

Comments before the imports are untouched, since they might be large block comments (license) or other things we don't want to move. Comments after the imports are also untouched.

(This is on top of my sortImports changes)