### PR TITLE
Add support for `export * from`, export as default and more obtuse ES6 export syntaxes

### DIFF
--- a/lib/__tests__/findExports-test.js
+++ b/lib/__tests__/findExports-test.js
@@ -51,7 +51,14 @@ it('finds es6 exports', () => {
     export { bar, car as racecar };
     export let baz = 'baz';
     export { foo1 as bar1, foo2 as bar2 };
+    export * as ns from './foo';
     export const { haa, faa } = tor();
+    export const { har, faa: far } = tor();
+    export const { has, fas = {a:1,b:2} } = tor();
+    export const { hat, faa: fat = {a:1,b:2} } = tor();
+    export const { hax, ...fax } = tor();
+    export const [ hay, fay ] = tor();
+    export const [ haz, ...faz ] = tor();
     export const hooli = 'facebook';
     export function yo() {};
     export class Foo {}
@@ -64,11 +71,41 @@ it('finds es6 exports', () => {
       'baz',
       'bar1',
       'bar2',
+      'ns',
       'haa',
       'faa',
+      'har',
+      'far',
+      'has',
+      'fas',
+      'hat',
+      'fat',
+      'hax',
+      'fax',
+      'hay',
+      'fay',
+      'haz',
+      'faz',
       'hooli',
       'yo',
       'Foo',
+    ],
+    hasDefault: true,
+  });
+});
+
+it('finds renamed es6 default export', () => {
+  expect(
+    findExports(
+      `
+    import { foo1, foo2 } from 'foo';
+    export { foo1 as default, foo2 };
+  `,
+    ),
+  ).toEqual({
+    named: [
+      'default',
+      'foo2',
     ],
     hasDefault: true,
   });
@@ -471,6 +508,26 @@ describe('recursive exports', () => {
     ).toEqual({
       named: ['bar'],
       hasDefault: true,
+    });
+  });
+});
+
+describe('recursive ES6 exports', () => {
+  beforeEach(() => {
+    fs.__setFile(
+      '/path/to/foo.js',
+      'const foo = "42"; export const bar = 123; export { foo };',
+      { isDirectory: () => false },
+    );
+    requireRelative.resolve.mockImplementation(() => '/path/to/foo.js');
+  });
+
+  it('follows exported * from', () => {
+    expect(
+      findExports("export * from './foo';", '/path/to/file.js'),
+    ).toEqual({
+      named: ['bar', 'foo'],
+      hasDefault: false,
     });
   });
 });

--- a/lib/findExports.js
+++ b/lib/findExports.js
@@ -5,7 +5,18 @@ import requireRelative from 'require-relative';
 
 import parse from './parse';
 
-function findESNamedExports(node) {
+function findESNamedExports(
+  node,
+  {
+    absolutePathToFile,
+  },
+) {
+  if (node.type === 'ExportAllDeclaration') {
+    // Recurse the file referenced by the declaration
+    // eslint-disable-next-line no-use-before-define
+    return resolveNestedNamedExports(node, absolutePathToFile);
+  }
+
   if (node.type !== 'ExportNamedDeclaration') {
     return [];
   }
@@ -27,11 +38,49 @@ function findESNamedExports(node) {
 
   const result = [];
   node.declaration.declarations.forEach(({ id }) => {
-    if (id.type === 'ObjectPattern') {
-      // export const { foo, bar } = something();
-      result.push(...id.properties.map(({ key }) => key.name));
-    } else {
+    // Always check for type === 'Identifier' before adding name
+    if (id.type === 'Identifier') {
+      // export const foo = 'bar'
       result.push(id.name);
+    } else if (id.type === 'ObjectPattern') {
+      // export const { foo, bar } = something();
+      id.properties.forEach((property) => {
+        if (property.type === 'ObjectProperty') {
+          // use value instead of key, since destructuring can remapped the
+          // key to a new name
+          // ie. export const { foo, bar: baz } = something();
+          //                     key ^^^  ^^^ value
+          if (property.value.type === 'Identifier') {
+            result.push(property.value.name);
+          } else if (property.value.type === 'AssignmentPattern') {
+            // Here's where things start getting weird
+            // `with default: export const {
+            //    foo,
+            //    bar = {a:1,b:2}
+            //  } = someObject`
+            // `renamed default: export const {
+            //    foo,
+            //    bar: baz = {a:1,b:2}
+            //  } = someObject`
+            if (property.value.left.type === 'Identifier') {
+              result.push(property.value.left.name);
+            }
+          }
+        } else if (property.type === 'RestProperty') {
+          // export const { foo, ...rest } = something();
+          result.push(property.argument.name);
+        }
+      });
+    } else if (id.type === 'ArrayPattern') {
+      // export const [ foo, bar ] = something();
+      id.elements.forEach((element) => {
+        if (element.type === 'Identifier') {
+          result.push(element.name);
+        } else if (element.type === 'RestElement') {
+          // export const [ foo, ...rest ] = something();
+          result.push(element.argument.name);
+        }
+      });
     }
   });
   return result;
@@ -52,6 +101,15 @@ function resolveNestedNamedExports(node, absolutePathToFile) {
     // module.exports = require('someOtherFile.js');
     const pathToRequiredFile = requireRelative.resolve(
       node.arguments[0].value,
+      path.dirname(absolutePathToFile));
+
+    const requiredFileContent = fs.readFileSync(pathToRequiredFile, 'utf8');
+    // eslint-disable-next-line no-use-before-define
+    const { named } = findExports(requiredFileContent, pathToRequiredFile);
+    return named;
+  } else if (node.type === 'ExportAllDeclaration') {
+    const pathToRequiredFile = requireRelative.resolve(
+      node.source.value,
       path.dirname(absolutePathToFile));
 
     const requiredFileContent = fs.readFileSync(pathToRequiredFile, 'utf8');
@@ -212,7 +270,11 @@ function findNamedExports(
 ) {
   const result = [];
   nodes.forEach((node) => {
-    result.push(...findESNamedExports(node));
+    result.push(
+      ...findESNamedExports(node, {
+        absolutePathToFile,
+      }),
+    );
     result.push(
       ...findCommonJSExports(node, {
         definedNames,
@@ -313,7 +375,9 @@ export default function findExports(data, absolutePathToFile) {
     definedNames,
     aliasesForExports,
   });
-  let hasDefault = hasDefaultExport(rootNodes) || aliasesForExports.size > 1;
+  let hasDefault = hasDefaultExport(rootNodes) ||
+                   aliasesForExports.size > 1 ||
+                   named.includes('default');
   if (!hasDefault) {
     const rawExportedId = findRawDefaultExport(data);
     hasDefault = !!rawExportedId;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -11,6 +11,7 @@ export default function parse(fileContent: String): Object {
       'objectRestSpread',
       'decorators',
       'classProperties',
+      'exportExtensions',
       'dynamicImport',
     ],
     sourceType: 'module',

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "babel-plugin-jsx": "^1.2.0",
     "babel-plugin-syntax-flow": "^6.18.0",
-    "babylon": "^6.14.1",
+    "babylon": "^6.17.4",
     "commander": "^2.9.0",
     "fb-watchman": "^2.0.0",
     "glob": "^7.1.1",


### PR DESCRIPTION
Added support for:
- Recursive export from file `export * from './foo'`
- namespace exports `export * as ns from './foo'`
  (uses babylon `exportExtensions` plugin)
- Renaming as default `export { foo, bar as default }`
- Renaming during destructure `export const { foo, bar: baz } = someObject`
- Default values `export const { foo, bar = {a:1, b:2} } = someObject`
- Rename during destructure with defaults:
    `export const {
      foo,
      bar: baz = {a: 1, b: 2}
    } = someObject`
- Rest parameter `export const { foo, ...bar } = someObject`
- Array destructure `export const [ foo, bar ] = someObject`
- Array rest parameter `export const [ foo, ...bar ] = someObject`