### PR TITLE
Update Meteor environment to support api.mainModule

### DIFF
--- a/lib/__tests__/Configuration-test.js
+++ b/lib/__tests__/Configuration-test.js
@@ -2,6 +2,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import requireRelative from 'require-relative';
 
 import Configuration from '../Configuration';
 import FileUtils from '../FileUtils';
@@ -10,6 +11,7 @@ import version from '../version';
 jest.mock('../FileUtils');
 jest.mock('../version');
 jest.mock('fs');
+jest.mock('require-relative');
 
 describe('Configuration', () => {
   afterEach(() => {
@@ -381,6 +383,8 @@ describe('Configuration', () => {
         `
 john:foo
 jane:bar
+john:foobar
+jane:barbaz
         `.trim(),
         { isDirectory: () => false },
       );
@@ -389,6 +393,8 @@ jane:bar
         `
 john:foo@1.0.0
 jane:bar@0.0.1
+john:foobar@1.0.0
+jane:barbaz@0.0.1
         `.trim(),
         { isDirectory: () => false },
       );
@@ -480,6 +486,284 @@ jane:bar@0.0.1
           ],
         },
       );
+      // Atmosphere package john:foobar files
+      FileUtils.__setFile(
+        path.join(
+          os.homedir(),
+          '.meteor',
+          'packages',
+          'john_foobar',
+          '1.0.0',
+          'isopack.json',
+        ),
+        {
+          name: 'foobar',
+          summary: 'Metasyntactic package name #3',
+          version: '1.0.0',
+          isTest: false,
+          'isopack-2': {
+            builds: [
+              {
+                kind: 'main',
+                arch: 'os',
+                path: 'os.json',
+              },
+            ],
+          },
+        },
+      );
+      FileUtils.__setFile(
+        path.join(
+          os.homedir(),
+          '.meteor',
+          'packages',
+          'john_foobar',
+          '1.0.0',
+          'os.json',
+        ),
+        {
+          format: 'isopack-2-unibuild',
+          declaredExports: [
+          ],
+          resources: [
+            {
+              type: 'source',
+              extension: 'js',
+              file: 'os/check-npm-versions.js',
+              length: 178,
+              offset: 0,
+              path: 'check-npm-versions.js',
+              hash: '7f6009ada7f566cbcfa441c7950448410a091512',
+              fileOptions: {},
+            },
+            {
+              type: 'source',
+              extension: 'js',
+              file: 'os/exports.js',
+              length: 241,
+              offset: 0,
+              path: 'exports.js',
+              hash: '85680aa23dc24bbd98196e191633a75fb7a46755',
+              fileOptions: {
+                mainModule: true,
+              },
+            },
+            {
+              type: 'source',
+              extension: 'js',
+              file: 'os/Baz.js',
+              length: 8713,
+              offset: 0,
+              path: 'Baz.js',
+              hash: 'f202d25ce0d36a2c3b7d5f5ac97b667ba4118aa9',
+              fileOptions: {
+                lazy: true,
+              },
+            },
+          ],
+        },
+      );
+      fs.__setFile(
+        path.join(
+          os.homedir(),
+          '.meteor',
+          'packages',
+          'john_foobar',
+          '1.0.0',
+          'os',
+          'exports.js',
+        ),
+        `
+export const foobarsball = () => {};
+export { foobarsballFunc } from './foobarsballFunc';
+export * from './foobarNs';
+        `.trim(),
+      );
+      fs.__setFile(
+        path.join(
+          os.homedir(),
+          '.meteor',
+          'packages',
+          'john_foobar',
+          '1.0.0',
+          'os',
+          'foobarsballFunc.js',
+        ),
+        `
+export const foobarsballFunc = () => {};
+export const notExportedFromModule = 'BAZ';
+        `.trim(),
+      );
+      fs.__setFile(
+        path.join(
+          os.homedir(),
+          '.meteor',
+          'packages',
+          'john_foobar',
+          '1.0.0',
+          'os',
+          'foobarNs.js',
+        ),
+        `
+export const foobarQux = () => {};
+export function foobarQuux () {};
+const foobarCorge = 'CORGE';
+export { foobarCorge };
+        `.trim(),
+      );
+      // local package jane:barbaz files
+      FileUtils.__setFile(
+        path.join(
+          process.cwd(),
+          '.meteor',
+          'local',
+          'isopacks',
+          'jane_barbaz',
+          'isopack.json',
+        ),
+        {
+          name: 'barbaz',
+          summary: 'Metasyntactic package name #2',
+          version: '0.0.1',
+          isTest: false,
+          'isopack-2': {
+            builds: [
+              {
+                kind: 'main',
+                arch: 'web.browser',
+                path: 'web.browser.json',
+              },
+            ],
+          },
+        },
+      );
+      FileUtils.__setFile(
+        path.join(
+          process.cwd(),
+          '.meteor',
+          'local',
+          'isopacks',
+          'jane_barbaz',
+          'web.browser.json',
+        ),
+        {
+          format: 'isopack-2-unibuild',
+          declaredExports: [
+          ],
+          resources: [
+            {
+              type: 'source',
+              extension: 'js',
+              file: 'web.browser/check-npm-versions.js',
+              length: 178,
+              offset: 0,
+              path: 'check-npm-versions.js',
+              hash: '7f6009ada7f566cbcfa441c7950448410a091512',
+              fileOptions: {},
+            },
+            {
+              type: 'source',
+              extension: 'js',
+              file: 'web.browser/main.js',
+              length: 241,
+              offset: 0,
+              path: 'main.js',
+              hash: '85680aa23dc24bbd98196e191633a75fb7a46755',
+              fileOptions: {
+                mainModule: true,
+              },
+            },
+            {
+              type: 'source',
+              extension: 'js',
+              file: 'web.browser/Baz.js',
+              length: 8713,
+              offset: 0,
+              path: 'Baz.js',
+              hash: 'f202d25ce0d36a2c3b7d5f5ac97b667ba4118aa9',
+              fileOptions: {
+                lazy: true,
+              },
+            },
+          ],
+        },
+      );
+      fs.__setFile(
+        path.join(
+          process.cwd(),
+          '.meteor',
+          'local',
+          'isopacks',
+          'jane_barbaz',
+          'web.browser',
+          'main.js',
+        ),
+        `
+export const barbazsketball = () => {};
+export { barbazsketballFunc } from './folder/barbazsketballFunc';
+export * from './barbazNs';
+        `.trim(),
+      );
+      fs.__setFile(
+        path.join(
+          process.cwd(),
+          '.meteor',
+          'local',
+          'isopacks',
+          'jane_barbaz',
+          'web.browser',
+          'folder',
+          'barbazsketballFunc.js',
+        ),
+        `
+export const barbazsketballFunc = () => {};
+export const notExportedFromModule = 'BAZ';
+        `.trim(),
+      );
+      fs.__setFile(
+        path.join(
+          process.cwd(),
+          '.meteor',
+          'local',
+          'isopacks',
+          'jane_barbaz',
+          'web.browser',
+          'barbazNs.js',
+        ),
+        `
+export const barbazQux = () => {};
+export function barbazQuux () {};
+const barbazCorge = 'CORGE';
+export { barbazCorge };
+        `.trim(),
+      );
+
+      // Mock requireRelative. so it returns a path to our mocked modules
+      requireRelative.resolve.mockImplementation((module) => {
+        let resolvedPath = '';
+        if (module === './barbazNs') {
+          resolvedPath = path.join(
+            process.cwd(),
+            '.meteor',
+            'local',
+            'isopacks',
+            'jane_barbaz',
+            'web.browser',
+            'barbazNs.js',
+          );
+        } else if (module === './foobarNs') {
+          resolvedPath = path.join(
+            os.homedir(),
+            '.meteor',
+            'packages',
+            'john_foobar',
+            '1.0.0',
+            'os',
+            'foobarNs.js',
+          );
+        }
+        return resolvedPath;
+      });
     });
 
     it('extracts namedExports and merges them into a single object', () => {
@@ -507,6 +791,20 @@ jane:bar@0.0.1
         // These namedExports should be extracted from the Meteor metadata
         'meteor/john:foo': ['foosball'],
         'meteor/jane:bar': ['barsketball'],
+        'meteor/john:foobar': [
+          'foobarsball',
+          'foobarsballFunc',
+          'foobarQux',
+          'foobarQuux',
+          'foobarCorge',
+        ],
+        'meteor/jane:barbaz': [
+          'barbazsketball',
+          'barbazsketballFunc',
+          'barbazQux',
+          'barbazQuux',
+          'barbazCorge',
+        ],
       });
     });
   });

--- a/lib/__tests__/findExports-test.js
+++ b/lib/__tests__/findExports-test.js
@@ -562,23 +562,3 @@ describe('recursive ES6 exports', () => {
     });
   });
 });
-
-describe('recursive ES6 Meteor exports', () => {
-  beforeEach(() => {
-    fs.__setFile(
-      '/path/to/foo.js',
-      'const foo = "42"; export const bar = 123; export { foo };',
-      { isDirectory: () => false },
-    );
-    requireRelative.resolve.mockImplementation(() => '/path/to/foo.js');
-  });
-
-  it('follows exported * from', () => {
-    expect(
-      findExports("export * from './foo';", '/path/to/file.js'),
-    ).toEqual({
-      named: ['bar', 'foo'],
-      hasDefault: false,
-    });
-  });
-});

--- a/lib/__tests__/findExports-test.js
+++ b/lib/__tests__/findExports-test.js
@@ -562,3 +562,23 @@ describe('recursive ES6 exports', () => {
     });
   });
 });
+
+describe('recursive ES6 Meteor exports', () => {
+  beforeEach(() => {
+    fs.__setFile(
+      '/path/to/foo.js',
+      'const foo = "42"; export const bar = 123; export { foo };',
+      { isDirectory: () => false },
+    );
+    requireRelative.resolve.mockImplementation(() => '/path/to/foo.js');
+  });
+
+  it('follows exported * from', () => {
+    expect(
+      findExports("export * from './foo';", '/path/to/file.js'),
+    ).toEqual({
+      named: ['bar', 'foo'],
+      hasDefault: false,
+    });
+  });
+});

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -3,7 +3,6 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import requireRelative from 'require-relative';
 
 import FileUtils from '../FileUtils';
 
@@ -248,7 +247,7 @@ function extractExportsFromMeteorPackage(
   if (!isopack) {
     // It is possible that this is a local package as opposed to a 3rd party
     // package. If so, it's isopack may be in
-    // <project-root>/.meteor/isopacks/<pkg>.
+    // <project-root>/.meteor/local/isopacks/<pkg>.
     isopackRoot = path.join(
       projectRootDir,
       '.meteor',
@@ -301,15 +300,14 @@ function extractExportsFromMeteorPackage(
     // mainModule, we need to attempt to scan it to find exports.
     if (buildIsopack.resources) {
       const mainModuleResource = buildIsopack.resources
-      .find((resource: Object): boolean => resource.fileOptions.mainModule === true);
+      .find((resource: Object): boolean => (
+        resource.fileOptions && resource.fileOptions.mainModule === true
+      ));
 
       if (mainModuleResource) {
-        // returns a set, which we iterate into declaredExports
-        const pathToRequiredFile = requireRelative.resolve(
-          mainModuleResource.file,
-          path.dirname(isopackRoot));
-
+        const pathToRequiredFile = path.join(isopackRoot, mainModuleResource.file);
         const requiredFileContent = fs.readFileSync(pathToRequiredFile, 'utf8');
+        // returns a set, which we iterate into declaredExports
         const { named } = findExports(requiredFileContent, pathToRequiredFile);
         named.forEach((name: string) => { declaredExports.add(name); });
       }

--- a/lib/environments/meteorEnvironment.js
+++ b/lib/environments/meteorEnvironment.js
@@ -3,10 +3,12 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import requireRelative from 'require-relative';
 
 import FileUtils from '../FileUtils';
 
 import findPackageDependencies from '../findPackageDependencies';
+import findExports from '../findExports';
 
 const coreModules = [
   'meteor/accounts-base',
@@ -295,8 +297,23 @@ function extractExportsFromMeteorPackage(
       }
     });
 
-    // TODO: If the "resources" section of the buildIsopack specifies a
+    // If the "resources" section of the buildIsopack specifies a
     // mainModule, we need to attempt to scan it to find exports.
+    if (buildIsopack.resources) {
+      const mainModuleResource = buildIsopack.resources
+      .find((resource: Object): boolean => resource.fileOptions.mainModule === true);
+
+      if (mainModuleResource) {
+        // returns a set, which we iterate into declaredExports
+        const pathToRequiredFile = requireRelative.resolve(
+          mainModuleResource.file,
+          path.dirname(isopackRoot));
+
+        const requiredFileContent = fs.readFileSync(pathToRequiredFile, 'utf8');
+        const { named } = findExports(requiredFileContent, pathToRequiredFile);
+        named.forEach((name: string) => { declaredExports.add(name); });
+      }
+    }
   });
 
   return Array.from(declaredExports);
@@ -375,6 +392,8 @@ export default {
 
     const moduleSpecifiers = [];
 
+    // DEBUG: should this also include preprocessor files?
+    // ie. .jade, .pug, .less, .scss, .sass
     ['.html', '.css'].forEach((ext: string) => {
       const moduleSpecifier = `${basePath}${ext}`;
       if (fs.existsSync(path.join(config.workingDirectory, moduleSpecifier))) {


### PR DESCRIPTION
Update to `extractExportsFromMeteorPackage` in `meteorEnvironment.js` to look
for a mainModule in the isoPack and uses the updated findExports from #435 to
parse the source file for named exports.

I could use some help adding tests for this. 
Should I import meteorEnvironment, mock an isoPack file and feed that into 
the `namedExports` function?