### PR TITLE
Handle Flow type-alias exports and imports

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -39,7 +39,7 @@ const DEFAULT_CONFIG = {
   cacheLocation: ({ config }: Object): string => {
     const hash = crypto
       .createHash('md5')
-      .update(`${config.workingDirectory}-v3`)
+      .update(`${config.workingDirectory}-v4`)
       .digest('hex');
     return path.join(os.tmpdir(), `import-js-${hash}.db`);
   },

--- a/lib/ExportsStorage.js
+++ b/lib/ExportsStorage.js
@@ -9,9 +9,10 @@ function normalizedExportName(string) {
 }
 
 function normalizeRows(rows) {
-  // currently just casts `isDefault` to boolean
-  return rows.map(({ isDefault, ...other }) => ({
+  // currently just casts `isDefault` and `isType` to boolean
+  return rows.map(({ isDefault, isType, ...other }) => ({
     isDefault: !!isDefault,
+    isType: !!isType,
     ...other,
   }));
 }
@@ -48,6 +49,7 @@ export default class ExportsStorage {
             CREATE TABLE exports (
               name VARCHAR(100),
               isDefault INTEGER,
+              isType INTEGER,
               path TEXT,
               packageName VARCHAR(100)
             )
@@ -64,6 +66,7 @@ export default class ExportsStorage {
                   name,
                   path,
                   isDefault,
+                  isType,
                   packageName,
                 )
               `,
@@ -197,15 +200,16 @@ export default class ExportsStorage {
     });
   }
 
-  _insert({ name, pathToFile, isDefault, packageName, additional }) {
+  _insert({ name, pathToFile, isDefault, isType, packageName, additional }) {
     const exportName = isDefault ? normalizedExportName(name) : name;
     return Promise.all([
       new Promise((resolve, reject) => {
         this.db.run(
-          'INSERT INTO exports (name, path, isDefault, packageName) VALUES (?, ?, ?, ?)',
+          'INSERT INTO exports (name, path, isDefault, isType, packageName) VALUES (?, ?, ?, ?, ?)',
           exportName,
           pathToFile,
           isDefault,
+          isType,
           packageName,
           (err) => {
             if (err) {
@@ -223,10 +227,11 @@ export default class ExportsStorage {
         // search results
         if (!additional) {
           this.db.run(
-            'INSERT INTO exports_full_text_search_index VALUES (?, ?, ?, ?)',
+            'INSERT INTO exports_full_text_search_index VALUES (?, ?, ?, ?, ?)',
             name,
             pathToFile,
             isDefault,
+            isType,
             packageName,
             (err) => {
               if (err) {
@@ -243,14 +248,19 @@ export default class ExportsStorage {
     ]);
   }
 
-  update({ names, defaultNames, pathToFile, mtime, packageName }) {
+  update({ names = [], types = [], defaultNames, pathToFile, mtime, packageName }) {
     return this.remove(pathToFile).then(() =>
       this.updateMtime(pathToFile, mtime, packageName).then(() => {
         const promises = names.map(name =>
-          this._insert({ name, pathToFile, isDefault: false, packageName }));
+          this._insert({ name, pathToFile, isDefault: false, isType: false, packageName }));
+        promises.push(types.map(name =>
+          this._insert({ name, pathToFile, isDefault: false, isType: true, packageName })),
+        );
         promises.push(
           ...defaultNames.map(({ name, additional }) =>
-            this._insert({ name, pathToFile, isDefault: true, packageName, additional }),
+            this._insert(
+              { name, pathToFile, isDefault: true, isType: false, packageName, additional },
+            ),
           ),
         );
         return Promise.all(promises);
@@ -322,7 +332,7 @@ export default class ExportsStorage {
     return new Promise((resolve, reject) => {
       this.db.all(
         `
-          SELECT name, path, isDefault, packageName
+          SELECT name, path, isDefault, isType, packageName
           FROM exports WHERE (
             (name = ? AND isDefault = 0) OR
             (name = ? AND isDefault = 1)
@@ -345,7 +355,7 @@ export default class ExportsStorage {
     return new Promise((resolve, reject) => {
       this.db.all(
         `
-          SELECT name, path, isDefault, packageName
+          SELECT name, path, isDefault, isType, packageName
           FROM exports_full_text_search_index WHERE name MATCH ?
           COLLATE NOCASE
         `,

--- a/lib/ImportStatement.js
+++ b/lib/ImportStatement.js
@@ -30,10 +30,12 @@ function equalsAndValue(
 export default class ImportStatement {
   assignment: ?string;
   declarationKeyword: ?string;
+  hasTypeKeyword: ?boolean;
   defaultImport: ?string;
   hasSideEffects: boolean;
   importFunction: ?string;
   namedImports: Array<Object>;
+  areOnlyTypes: boolean;
   originalImportString: ?string;
   path: string;
 
@@ -41,29 +43,35 @@ export default class ImportStatement {
     {
       assignment,
       declarationKeyword,
+      hasTypeKeyword,
       defaultImport,
       hasSideEffects,
       importFunction,
       namedImports = [],
+      areOnlyTypes = false,
       originalImportString,
       path,
     }: {
       assignment?: ?string,
       declarationKeyword?: ?string,
+      hasTypeKeyword?: ?boolean,
       defaultImport?: ?string,
       hasSideEffects: boolean,
       importFunction?: ?string,
       namedImports?: Array<Object>,
+      areOnlyTypes?: boolean,
       originalImportString?: ?string,
       path: string,
     } = {},
   ) {
     this.assignment = assignment;
     this.declarationKeyword = declarationKeyword;
+    this.hasTypeKeyword = hasTypeKeyword;
     this.defaultImport = defaultImport;
     this.hasSideEffects = hasSideEffects;
     this.importFunction = importFunction;
     this.namedImports = namedImports;
+    this.areOnlyTypes = areOnlyTypes;
     this.originalImportString = originalImportString;
     this.path = path;
   }
@@ -230,6 +238,9 @@ export default class ImportStatement {
         if (!namedImport) {
           this.namedImports.push(named);
           modified = true;
+          if (this.areOnlyTypes && !named.isType) {
+            this.areOnlyTypes = false;
+          }
         }
       });
       if (modified) {
@@ -283,21 +294,28 @@ export default class ImportStatement {
     });
 
     let prefix = '';
-    if (this.declarationKeyword === 'import' && this.defaultImport) {
-      prefix = `${this.defaultImport}, `;
+    if (this.declarationKeyword === 'import') {
+      if (this.defaultImport) {
+        prefix = `${this.defaultImport}, `;
+      } else if (this.areOnlyTypes) {
+        prefix = 'type ';
+      }
     }
 
     const named = this.namedImports.map(({
       localName,
       importedName,
+      isType,
     }: {
       localName: string,
       importedName: ?string,
+      isType?: boolean,
     }): string => {
+      const typePrefix = isType && (!this.areOnlyTypes || this.defaultImport) ? 'type ' : '';
       if (!importedName) {
-        return localName;
+        return `${typePrefix}${localName}`;
       }
-      return `${importedName} as ${localName}`;
+      return `${typePrefix}${importedName} as ${localName}`;
     });
 
     const namedOneLine = `{ ${named.join(', ')} }`;

--- a/lib/ImportStatement.js
+++ b/lib/ImportStatement.js
@@ -35,7 +35,7 @@ export default class ImportStatement {
   hasSideEffects: boolean;
   importFunction: ?string;
   namedImports: Array<Object>;
-  areOnlyTypes: boolean;
+  areOnlyTypes: boolean; // true if namedImports are all 'type' imports
   originalImportString: ?string;
   path: string;
 

--- a/lib/JsModule.js
+++ b/lib/JsModule.js
@@ -20,6 +20,7 @@ function stripNodeModules(path: string): string {
 // Class that represents a js module found in the file system
 export default class JsModule {
   hasNamedExports: ?boolean;
+  isType: boolean;
   importPath: string;
   filePath: string;
   mainFile: ?string;
@@ -28,6 +29,7 @@ export default class JsModule {
 
   /**
    * @param {Boolean} hasNamedExports
+   * @param {Boolean} isType
    * @param {String|null} opts.makeRelativeTo a path to a different file which
    *   the resulting import path should be relative to.
    * @param {String} opts.relativeFilePath a full path to the file, relative to
@@ -41,6 +43,7 @@ export default class JsModule {
   static construct(
     {
       hasNamedExports,
+      isType = false,
       makeRelativeTo,
       relativeFilePath,
       stripFileExtensions,
@@ -48,6 +51,7 @@ export default class JsModule {
       workingDirectory = process.cwd(),
     }: {
       hasNamedExports?: boolean,
+      isType?: boolean,
       makeRelativeTo?: ?string,
       relativeFilePath: string,
       stripFileExtensions: Array<string>,
@@ -77,6 +81,7 @@ export default class JsModule {
     jsModule.importPath = importPath;
     jsModule.mainFile = mainFile;
     jsModule.hasNamedExports = hasNamedExports;
+    jsModule.isType = isType;
     jsModule.variableName = variableName;
     if (makeRelativeTo) {
       jsModule.makeRelativeTo(makeRelativeTo);
@@ -89,15 +94,18 @@ export default class JsModule {
   constructor(
     {
       hasNamedExports,
+      isType = false,
       importPath,
       variableName,
     }: {
       hasNamedExports?: boolean,
+      isType?: boolean,
       importPath: string,
       variableName: string,
     } = {},
   ) {
     this.hasNamedExports = hasNamedExports;
+    this.isType = isType;
     this.importPath = importPath;
     this.variableName = variableName;
   }
@@ -162,7 +170,7 @@ export default class JsModule {
     let namedImports = [];
     let defaultImport = '';
     if (this.hasNamedExports) {
-      namedImports = [{ localName: this.variableName }];
+      namedImports = [{ localName: this.variableName, isType: this.isType }];
     } else {
       defaultImport = this.variableName;
     }
@@ -180,6 +188,7 @@ export default class JsModule {
       hasSideEffects: false,
       importFunction: config.get('importFunction', { pathToImportedModule }),
       namedImports,
+      areOnlyTypes: this.isType,
       path: config.get('moduleNameFormatter', {
         pathToImportedModule,
         // TODO figure out a more holistic solution than stripping node_modules

--- a/lib/ModuleFinder.js
+++ b/lib/ModuleFinder.js
@@ -164,7 +164,7 @@ export default class ModuleFinder {
     const fullPath = path.join(this.workingDirectory, pathToFile);
     readFile(fullPath)
       .then((data) => {
-        let exports = { named: [], hasDefault: true };
+        let exports = { named: [], typed: [], hasDefault: true };
         try {
           exports = findExports(data, fullPath);
         } catch (e) {
@@ -172,8 +172,8 @@ export default class ModuleFinder {
             `Failed to parse ${pathToFile}: ${e.message}\n${e.stack}`,
           );
         }
-        if (exports.named.length || exports.hasDefault) {
-          const all = exports.named.slice(0);
+        if (exports.named.length || exports.typed.length || exports.hasDefault) {
+          const all = [...exports.named, ...exports.typed.map(t => `type ${t}`)];
           if (exports.hasDefault) {
             all.push('default');
           }
@@ -194,6 +194,7 @@ export default class ModuleFinder {
         this.storage
           .update({
             names: exports.named,
+            types: exports.typed,
             defaultNames,
             pathToFile,
             mtime,

--- a/lib/__tests__/ExportsStorage-test.js
+++ b/lib/__tests__/ExportsStorage-test.js
@@ -38,7 +38,7 @@ it('can search for modules', () => {
       mtime: 1,
     }),
     subject.update({
-      types: ['Bar'],
+      types: ['BarType'],
       pathToFile: './types/Bar.js',
       defaultNames: [],
       mtime: 1,
@@ -51,16 +51,17 @@ it('can search for modules', () => {
     }),
   ]).then(() => subject.search('bar*').then((rows) => {
     expect(rows.length).toEqual(3);
+    rows.sort((left, right) => left.name.localeCompare(right.name));
 
     expect(rows[0].path).toEqual('./lib/Bar.js');
     expect(rows[0].name).toEqual('Bar');
 
-    expect(rows[1].path).toEqual('./types/Bar.js');
-    expect(rows[1].name).toEqual('Bar');
-    expect(rows[1].isType).toBeTruthy();
+    expect(rows[1].path).toEqual('./lib/BarBar.js');
+    expect(rows[1].name).toEqual('barbar');
 
-    expect(rows[2].path).toEqual('./lib/BarBar.js');
-    expect(rows[2].name).toEqual('barbar');
+    expect(rows[2].path).toEqual('./types/Bar.js');
+    expect(rows[2].name).toEqual('BarType');
+    expect(rows[2].isType).toBeTruthy();
   }));
 });
 

--- a/lib/__tests__/ExportsStorage-test.js
+++ b/lib/__tests__/ExportsStorage-test.js
@@ -38,18 +38,29 @@ it('can search for modules', () => {
       mtime: 1,
     }),
     subject.update({
+      types: ['Bar'],
+      pathToFile: './types/Bar.js',
+      defaultNames: [],
+      mtime: 1,
+    }),
+    subject.update({
       names: [],
       pathToFile: './lib/BarBar.js',
       defaultNames: [{ name: 'barbar' }],
       mtime: 1,
     }),
   ]).then(() => subject.search('bar*').then((rows) => {
-    expect(rows.length).toEqual(2);
+    expect(rows.length).toEqual(3);
+
     expect(rows[0].path).toEqual('./lib/Bar.js');
     expect(rows[0].name).toEqual('Bar');
 
-    expect(rows[1].path).toEqual('./lib/BarBar.js');
-    expect(rows[1].name).toEqual('barbar');
+    expect(rows[1].path).toEqual('./types/Bar.js');
+    expect(rows[1].name).toEqual('Bar');
+    expect(rows[1].isType).toBeTruthy();
+
+    expect(rows[2].path).toEqual('./lib/BarBar.js');
+    expect(rows[2].name).toEqual('barbar');
   }));
 });
 

--- a/lib/__tests__/ImportStatement-test.js
+++ b/lib/__tests__/ImportStatement-test.js
@@ -36,8 +36,8 @@ describe('ImportStatement', () => {
         declarationKeyword: 'import',
         defaultImport: 'foo',
         hasSideEffects: false,
-        originalImportString: "import foo, { bar } from './lib/foo';",
-        namedImports: [{ localName: 'bar' }],
+        originalImportString: "import foo, { bar, type baz } from './lib/foo';",
+        namedImports: [{ localName: 'bar' }, { localName: 'bar', isType: true }],
         path: './lib/foo',
       });
       expect(statement.isParsedAndUntouched()).toBe(true);
@@ -50,8 +50,8 @@ describe('ImportStatement', () => {
           declarationKeyword: 'import',
           defaultImport: 'foo',
           hasSideEffects: false,
-          originalImportString: "import foo, { bar } from './lib/foo';",
-          namedImports: [{ localName: 'bar' }],
+          originalImportString: "import foo, { bar, type baz } from './lib/foo';",
+          namedImports: [{ localName: 'bar' }, { localName: 'bar', isType: true }],
           path: './lib/foo',
         });
         statement.deleteVariable('foo');
@@ -66,8 +66,8 @@ describe('ImportStatement', () => {
           declarationKeyword: 'import',
           defaultImport: 'foo',
           hasSideEffects: false,
-          originalImportString: "import foo, { bar } from './lib/foo';",
-          namedImports: [{ localName: 'bar' }],
+          originalImportString: "import foo, { bar, type baz } from './lib/foo';",
+          namedImports: [{ localName: 'bar' }, { localName: 'bar', isType: true }],
           path: './lib/foo',
         });
         statement.deleteVariable('bar');
@@ -80,8 +80,8 @@ describe('ImportStatement', () => {
         declarationKeyword: 'import',
         defaultImport: 'foo',
         hasSideEffects: false,
-        originalImportString: "import foo, { bar } from './lib/foo';",
-        namedImports: [{ localName: 'bar' }],
+        originalImportString: "import foo, { bar, type baz } from './lib/foo';",
+        namedImports: [{ localName: 'bar' }, { localName: 'bar', isType: true }],
         path: './lib/foo',
       });
       statement.deleteVariable('somethingElse');
@@ -139,7 +139,7 @@ describe('ImportStatement', () => {
         namedImports: [
           { localName: 'foo' },
           { localName: 'bar' },
-          { localName: 'baz' },
+          { localName: 'baz', isType: true },
         ],
       });
 
@@ -151,7 +151,7 @@ describe('ImportStatement', () => {
         defaultImport: 'foo',
         namedImports: [
           { localName: 'bar' },
-          { localName: 'baz' },
+          { localName: 'baz', isType: true },
         ],
       });
 
@@ -197,17 +197,38 @@ describe('ImportStatement', () => {
 
     it('merges the named imports when both existing and new ones exist', () => {
       const existing = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
-      const newStatement = new ImportStatement({ namedImports: [{ localName: 'bar' }] });
+      const newStatement = new ImportStatement({ namedImports: [{ localName: 'bar', isType: true }] });
       existing.merge(newStatement);
       expect(existing.namedImports).toEqual([
+        { localName: 'bar', isType: true },
+        { localName: 'foo' },
+      ]);
+    });
+
+    it('handles the inclusion of non-type named imports into type-only imports', () => {
+      const existing = new ImportStatement({ namedImports: [{ localName: 'foo', isType: true }], areOnlyTypes: true });
+      const newStatement = new ImportStatement({ namedImports: [{ localName: 'bar' }] });
+      existing.merge(newStatement);
+      expect(existing.areOnlyTypes).toBeFalsy();
+      expect(existing.namedImports).toEqual([
         { localName: 'bar' },
+        { localName: 'foo', isType: true },
+      ]);
+    });
+
+    it('merges the named imports when both existing and new ones exist', () => {
+      const existing = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
+      const newStatement = new ImportStatement({ namedImports: [{ localName: 'bar', isType: true }] });
+      existing.merge(newStatement);
+      expect(existing.namedImports).toEqual([
+        { localName: 'bar', isType: true },
         { localName: 'foo' },
       ]);
     });
 
     it('does not duplicate named imports', () => {
       const existing = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
-      const newStatement = new ImportStatement({ namedImports: [{ localName: 'foo' }] });
+      const newStatement = new ImportStatement({ namedImports: [{ localName: 'foo', isType: true }] });
       existing.merge(newStatement);
       expect(existing.namedImports).toEqual([{ localName: 'foo' }]);
     });
@@ -280,11 +301,11 @@ describe('ImportStatement', () => {
       it('is ok with named imports', () => {
         const statement = new ImportStatement({
           declarationKeyword: 'import',
-          namedImports: [{ localName: 'foo' }, { localName: 'bar' }],
+          namedImports: [{ localName: 'foo' }, { localName: 'bar', isType: true }, { localName: 'baz' }],
           path: './lib/foo',
         });
         expect(statement.toImportStrings(80, '  ')).toEqual([
-          "import { foo, bar } from './lib/foo';",
+          "import { foo, type bar, baz } from './lib/foo';",
         ]);
       });
 
@@ -293,9 +314,9 @@ describe('ImportStatement', () => {
         const statement = new ImportStatement({
           declarationKeyword: 'import',
           namedImports: [
-            { localName: 'foo' },
+            { localName: 'foo', isType: true },
             { localName: 'bar' },
-            { localName: 'baz' },
+            { localName: 'baz', isType: true },
             { localName: 'fizz' },
             { localName: 'buzz' },
           ],
@@ -303,7 +324,7 @@ describe('ImportStatement', () => {
         });
 
         expect(statement.toImportStrings(50, '  ')).toEqual([
-          `import {\n  foo,\n  bar,\n  baz,\n  fizz,\n  buzz,\n} from '${path}';`,
+          `import {\n  type foo,\n  bar,\n  type baz,\n  fizz,\n  buzz,\n} from '${path}';`,
         ]);
       });
 
@@ -311,11 +332,11 @@ describe('ImportStatement', () => {
         const statement = new ImportStatement({
           declarationKeyword: 'import',
           defaultImport: 'foo',
-          namedImports: [{ localName: 'bar' }, { localName: 'baz' }],
+          namedImports: [{ localName: 'bar' }, { localName: 'baz', isType: true }],
           path: './lib/foo',
         });
         expect(statement.toImportStrings(80, '  ')).toEqual([
-          "import foo, { bar, baz } from './lib/foo';",
+          "import foo, { bar, type baz } from './lib/foo';",
         ]);
       });
 
@@ -326,15 +347,78 @@ describe('ImportStatement', () => {
           defaultImport: 'foo',
           namedImports: [
             { localName: 'bar' },
-            { localName: 'baz' },
+            { localName: 'baz', isType: true },
             { localName: 'fizz' },
-            { localName: 'buzz' },
+            { localName: 'buzz', isType: true },
           ],
           path,
         });
 
         expect(statement.toImportStrings(50, '  ')).toEqual([
-          `import foo, {\n  bar,\n  baz,\n  fizz,\n  buzz,\n} from '${path}';`,
+          `import foo, {\n  bar,\n  type baz,\n  fizz,\n  type buzz,\n} from '${path}';`,
+        ]);
+      });
+
+      it('is ok with only type named imports', () => {
+        const statement = new ImportStatement({
+          declarationKeyword: 'import',
+          namedImports: [{ localName: 'foo', isType: true }, { localName: 'bar', isType: true }],
+          areOnlyTypes: true,
+          path: './lib/foo',
+        });
+        expect(statement.toImportStrings(80, '  ')).toEqual([
+          "import type { foo, bar } from './lib/foo';",
+        ]);
+      });
+
+      it('wraps long imports with only type named imports', () => {
+        const path = 'also_very_long_for_some_reason';
+        const statement = new ImportStatement({
+          declarationKeyword: 'import',
+          namedImports: [
+            { localName: 'foo', isType: true },
+            { localName: 'bar', isType: true },
+            { localName: 'baz', isType: true },
+          ],
+          areOnlyTypes: true,
+          path,
+        });
+
+        expect(statement.toImportStrings(50, '  ')).toEqual([
+          `import type {\n  foo,\n  bar,\n  baz,\n} from '${path}';`,
+        ]);
+      });
+
+      it('is ok with default import and only type named imports', () => {
+        const statement = new ImportStatement({
+          declarationKeyword: 'import',
+          defaultImport: 'foo',
+          namedImports: [{ localName: 'bar', isType: true }, { localName: 'baz', isType: true }],
+          areOnlyTypes: true,
+          path: './lib/foo',
+        });
+        expect(statement.toImportStrings(80, '  ')).toEqual([
+          "import foo, { type bar, type baz } from './lib/foo';",
+        ]);
+      });
+
+      it('wraps long imports with default and only type named imports', () => {
+        const path = 'also_very_long_for_some_reason';
+        const statement = new ImportStatement({
+          declarationKeyword: 'import',
+          defaultImport: 'foo',
+          namedImports: [
+            { localName: 'bar', isType: true },
+            { localName: 'baz', isType: true },
+            { localName: 'fizz', isType: true },
+            { localName: 'buzz', isType: true },
+          ],
+          areOnlyTypes: true,
+          path,
+        });
+
+        expect(statement.toImportStrings(50, '  ')).toEqual([
+          `import foo, {\n  type bar,\n  type baz,\n  type fizz,\n  type buzz,\n} from '${path}';`,
         ]);
       });
     });

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -2329,6 +2329,61 @@ foo();
       );
     });
 
+    describe('with a module exporting types and names', () => {
+      beforeEach(() => {
+        existingFiles = ['star/foo.js'];
+        readFile.mockImplementation(() => Promise.resolve(`
+          export default function() {};
+          export { bar };
+          export type Baz = {};
+          export type Faz = {};
+        `));
+      });
+
+      describe('when one undefined type exists', () => {
+        beforeEach(() => {
+          text = 'Baz';
+        });
+
+        it('imports that type', () => {
+          expect(subject()).toEqual(
+            `
+import type { Baz } from './star/foo';
+
+Baz
+          `.trim(),
+          );
+        });
+
+        it('displays a message', () => {
+          subject();
+          expect(result.messages).toEqual(['Imported `Baz`.']);
+        });
+      });
+
+      describe('when a type import is set and undefined variables exists', () => {
+        beforeEach(() => {
+          text = `
+import type { Baz } from './star/foo';
+
+bar: Baz;
+foo();
+          `.trim();
+        });
+
+        it('moves the type prefix inside brackets and adds the named and default imports', () => {
+          expect(subject()).toEqual(
+            `
+import foo, { type Baz, bar } from './star/foo';
+
+bar: Baz;
+foo();
+          `.trim(),
+          );
+        });
+      });
+    });
+
     describe('when there is one `moduleSideEffectImports`', () => {
       beforeEach(() => {
         existingFiles = [];

--- a/lib/__tests__/ModuleFinder-test.js
+++ b/lib/__tests__/ModuleFinder-test.js
@@ -65,6 +65,7 @@ it('finds files', () => addFiles(['./foo/bar.js']).then(() =>
         path: './foo/bar.js',
         name: 'bar',
         isDefault: true,
+        isType: false,
         packageName: null,
       },
     ]);
@@ -78,6 +79,7 @@ it('finds package dependencies', () => addFiles([
       path: './node_modules/pacman/index.js',
       name: 'pacman',
       isDefault: true,
+      isType: false,
       packageName: 'pacman',
     },
   ]);
@@ -91,6 +93,7 @@ it('finds package dependencies not located in the local node_modules folder', ()
       path: '../../node_modules/hoisted/index.js',
       name: 'hoisted',
       isDefault: true,
+      isType: false,
       packageName: 'hoisted',
     },
   ]);
@@ -104,6 +107,7 @@ it('can ignore package prefixes', () => addFiles([
       path: './node_modules/react-packer/index.js',
       name: 'packer',
       isDefault: true,
+      isType: false,
       packageName: 'react-packer',
     },
   ]);
@@ -117,6 +121,7 @@ it('matches over the last folder name', () => addFiles([
       path: './Foo/bar.js',
       name: 'foobar',
       isDefault: true,
+      isType: false,
       packageName: null,
     },
   ]);
@@ -130,6 +135,7 @@ it('knows about plural when matching over folder name', () => addFiles([
       path: './Foos/bar.js',
       name: 'foobar',
       isDefault: true,
+      isType: false,
       packageName: null,
     },
   ]);

--- a/lib/__tests__/findCurrentImports-test.js
+++ b/lib/__tests__/findCurrentImports-test.js
@@ -62,7 +62,7 @@ module.exports = AlignmentRibbonPage;
 
 it('finds deconstructed import statements', () => {
   const currentFileContent = `
-import { foo, bar } from 'far';
+import { type foo, bar, type baz } from 'far';
   `.trim();
 
   const imports = findCurrentImports(
@@ -74,10 +74,69 @@ import { foo, bar } from 'far';
   imports.imports.forEach((imp) => {
     expect(imp.path).toEqual('far');
     expect(imp.declarationKeyword).toEqual('import');
-    expect(imp.namedImports).toEqual([{ localName: 'foo' }, { localName: 'bar' }]);
+    expect(imp.namedImports).toEqual([{ localName: 'foo', isType: true }, { localName: 'bar', isType: false }, { localName: 'baz', isType: true }]);
+    expect(imp.areOnlyTypes).toEqual(false);
   });
   expect(imports.range.start).toEqual(0);
   expect(imports.range.end).toEqual(1);
+});
+
+it('finds single type import statement', () => {
+  const currentFileContent = `
+import type { foo } from 'far';
+  `.trim();
+
+  const imports = findCurrentImports(
+    new Configuration('./foo.js'),
+    currentFileContent,
+    parse(currentFileContent),
+  );
+  expect(imports.imports.size()).toEqual(1);
+  imports.imports.forEach((imp) => {
+    expect(imp.path).toEqual('far');
+    expect(imp.declarationKeyword).toEqual('import');
+    expect(imp.namedImports).toEqual([{ localName: 'foo', isType: true }]);
+    expect(imp.areOnlyTypes).toEqual(true);
+  });
+});
+
+it('finds multiple type imports statement', () => {
+  const currentFileContent = `
+import type { foo, bar } from 'far';
+  `.trim();
+
+  const imports = findCurrentImports(
+    new Configuration('./foo.js'),
+    currentFileContent,
+    parse(currentFileContent),
+  );
+  expect(imports.imports.size()).toEqual(1);
+  imports.imports.forEach((imp) => {
+    expect(imp.path).toEqual('far');
+    expect(imp.declarationKeyword).toEqual('import');
+    expect(imp.namedImports).toEqual([{ localName: 'foo', isType: true }, { localName: 'bar', isType: true }]);
+    expect(imp.areOnlyTypes).toEqual(true);
+  });
+});
+
+it('finds mixed imports statement', () => {
+  const currentFileContent = `
+import far, { type foo, bar } from 'far';
+  `.trim();
+
+  const imports = findCurrentImports(
+    new Configuration('./foo.js'),
+    currentFileContent,
+    parse(currentFileContent),
+  );
+  expect(imports.imports.size()).toEqual(1);
+  imports.imports.forEach((imp) => {
+    expect(imp.path).toEqual('far');
+    expect(imp.declarationKeyword).toEqual('import');
+    expect(imp.defaultImport).toEqual('far');
+    expect(imp.namedImports).toEqual([{ localName: 'foo', isType: true }, { localName: 'bar', isType: false }]);
+    expect(imp.areOnlyTypes).toEqual(false);
+  });
 });
 
 it('finds deconstructed require statements', () => {

--- a/lib/__tests__/findExports-test.js
+++ b/lib/__tests__/findExports-test.js
@@ -18,7 +18,7 @@ it('finds no exports from export-less modules', () => {
     console.log('boo!');
   `,
     ),
-  ).toEqual({ named: [], hasDefault: false });
+  ).toEqual({ named: [], typed: [], hasDefault: false });
 });
 
 it('finds exports from json', () => {
@@ -36,6 +36,7 @@ it('finds exports from json', () => {
     ),
   ).toEqual({
     named: ['foo', 'bar'],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -62,6 +63,11 @@ it('finds es6 exports', () => {
     export const hooli = 'facebook';
     export function yo() {};
     export class Foo {}
+    export type Yak = string;
+    export type Yik<A, B, C> = {
+      property: A,
+      method(val: B): C,
+    };
   `,
     ),
   ).toEqual({
@@ -89,6 +95,10 @@ it('finds es6 exports', () => {
       'hooli',
       'yo',
       'Foo',
+    ],
+    typed: [
+      'Yak',
+      'Yik',
     ],
     hasDefault: true,
   });
@@ -120,6 +130,7 @@ it('does not blow up on object spreads', () => {
     ),
   ).toEqual({
     named: [],
+    typed: [],
     hasDefault: false,
   });
 });
@@ -139,6 +150,7 @@ it('finds CommonJS exports', () => {
     ),
   ).toEqual({
     named: ['foo', 'bar', 'car'],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -158,6 +170,7 @@ it('finds CommonJS exports not using the "module" prefix', () => {
     ),
   ).toEqual({
     named: ['foo', 'bar', 'car'],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -176,6 +189,7 @@ it('finds CommonJS exports using `exports.use`', () => {
     ),
   ).toEqual({
     named: ['should'],
+    typed: [],
     hasDefault: false,
   });
 });
@@ -190,6 +204,7 @@ it('does not fail on empty variable declarations', () => {
     ),
   ).toEqual({
     named: [],
+    typed: [],
     hasDefault: false,
   });
 });
@@ -207,6 +222,7 @@ it('finds CommonJS exports defined earlier in the file', () => {
     ),
   ).toEqual({
     named: ['foo', 'bar'],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -221,6 +237,7 @@ it('does not fail on CommonJS exports defined earlier as functions', () => {
     ),
   ).toEqual({
     named: [],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -237,6 +254,7 @@ it('finds CommonJS exports defined later in the file', () => {
     ),
   ).toEqual({
     named: ['foo', 'bar'],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -262,6 +280,7 @@ it('finds exports defined through Object.defineProperty', () => {
     ),
   ).toEqual({
     named: ['foo', 'bar'],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -278,6 +297,7 @@ it('finds CommonJS exports in a root, self-executing, function', () => {
     ),
   ).toEqual({
     named: ['foo'],
+    typed: [],
     hasDefault: true,
   });
 
@@ -292,6 +312,7 @@ it('finds CommonJS exports in a root, self-executing, function', () => {
     ),
   ).toEqual({
     named: ['foo'],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -312,6 +333,7 @@ it('finds inner CommonJS exports', () => {
     ),
   ).toEqual({
     named: [],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -329,6 +351,7 @@ it('finds exports when exports is reassigned', () => {
     ),
   ).toEqual({
     named: ['foo', 'bar'],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -396,6 +419,7 @@ module.exports = React;
       'version',
       '__spread',
     ],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -423,6 +447,7 @@ it('finds underscore exports', () => {
     ),
   ).toEqual({
     named: ['debounce', 'pluck'],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -452,6 +477,7 @@ exports.Foo = Foo.default;
     ),
   ).toEqual({
     named: ['Foo'],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -473,6 +499,7 @@ it('does not fail for inner exports that are not objects', () => {
     ),
   ).toEqual({
     named: [],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -492,6 +519,7 @@ describe('recursive exports', () => {
       findExports("module.exports = require('./foo');", '/path/to/file.js'),
     ).toEqual({
       named: ['bar'],
+      typed: [],
       hasDefault: true,
     });
   });
@@ -507,6 +535,7 @@ describe('recursive exports', () => {
       ),
     ).toEqual({
       named: ['bar'],
+      typed: [],
       hasDefault: true,
     });
   });

--- a/lib/__tests__/findExports-test.js
+++ b/lib/__tests__/findExports-test.js
@@ -117,6 +117,7 @@ it('finds renamed es6 default export', () => {
       'default',
       'foo2',
     ],
+    typed: [],
     hasDefault: true,
   });
 });
@@ -556,6 +557,7 @@ describe('recursive ES6 exports', () => {
       findExports("export * from './foo';", '/path/to/file.js'),
     ).toEqual({
       named: ['bar', 'foo'],
+      typed: [],
       hasDefault: false,
     });
   });

--- a/lib/findCurrentImports.js
+++ b/lib/findCurrentImports.js
@@ -12,24 +12,32 @@ function convertToImportStatement(node: Object): ?ImportStatement {
         spec.type === 'ImportNamespaceSpecifier',
     );
 
+    const namedImports = node.specifiers
+      .map((spec: Object): ?Object => {
+        if (spec.type !== 'ImportSpecifier') {
+          return undefined;
+        }
+        const isType = node.importKind === 'type' || spec.importKind === 'type';
+        if (spec.local.name !== spec.imported.name) {
+          return {
+            localName: spec.local.name,
+            importedName: spec.imported.name,
+            isType,
+          };
+        }
+        return {
+          localName: spec.local.name,
+          isType,
+        };
+      })
+      .filter(Boolean);
+
     return new ImportStatement({
       declarationKeyword: 'import',
       defaultImport: defaultSpecifier ? defaultSpecifier.local.name : undefined,
       hasSideEffects: node.specifiers.length === 0,
-      namedImports: node.specifiers
-        .map((spec: Object): ?Object => {
-          if (spec.type !== 'ImportSpecifier') {
-            return undefined;
-          }
-          if (spec.local.name !== spec.imported.name) {
-            return {
-              localName: spec.local.name,
-              importedName: spec.imported.name,
-            };
-          }
-          return { localName: spec.local.name };
-        })
-        .filter(Boolean),
+      namedImports,
+      areOnlyTypes: node.importKind === 'type',
       path: node.source.value,
     });
   }

--- a/lib/findExports.js
+++ b/lib/findExports.js
@@ -37,6 +37,11 @@ function findESNamedExports(
   }
 
   const result = [];
+
+  if (!node.declaration.declarations) {
+    return result;
+  }
+
   node.declaration.declarations.forEach(({ id }) => {
     // Always check for type === 'Identifier' before adding name
     if (id.type === 'Identifier') {
@@ -84,6 +89,22 @@ function findESNamedExports(
     }
   });
   return result;
+}
+
+function findFlowTypeExports(node) {
+  if (node.type !== 'ExportNamedDeclaration') {
+    return [];
+  }
+
+  if (!node.declaration) {
+    return [];
+  }
+
+  if (node.declaration.type === 'TypeAlias') {
+    return [node.declaration.id.name];
+  }
+
+  return [];
 }
 
 function resolveNestedNamedExports(node, absolutePathToFile) {
@@ -286,6 +307,14 @@ function findNamedExports(
   return result;
 }
 
+function findTypeExports(nodes) {
+  const result = [];
+  nodes.forEach((node) => {
+    result.push(...findFlowTypeExports(node));
+  });
+  return result;
+}
+
 function hasDefaultExport(nodes) {
   return nodes.some((node) => {
     if (node.type === 'ExportDefaultDeclaration') {
@@ -360,6 +389,7 @@ export default function findExports(data, absolutePathToFile) {
   if (/\.json$/.test(absolutePathToFile)) {
     return {
       named: Object.keys(JSON.parse(data)),
+      typed: [],
       hasDefault: true,
     };
   }
@@ -375,6 +405,7 @@ export default function findExports(data, absolutePathToFile) {
     definedNames,
     aliasesForExports,
   });
+  const typed = findTypeExports(rootNodes);
   let hasDefault = hasDefaultExport(rootNodes) ||
                    aliasesForExports.size > 1 ||
                    named.indexOf('default') !== -1;
@@ -390,6 +421,7 @@ export default function findExports(data, absolutePathToFile) {
   }
   return {
     named,
+    typed,
     hasDefault,
   };
 }

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -48,7 +48,7 @@ function findJsModulesFromModuleFinder(
     finder[method](normalizedName)
       .then((exports: Array<Object>) => {
         const modules = exports.map((
-          { name, path, isDefault, packageName }: Object,
+          { name, path, isDefault, isType, packageName }: Object,
         ): ?JsModule => {
           // Filter out modules that are in the `excludes` config.
           const isExcluded = config.get('excludes')
@@ -65,11 +65,13 @@ function findJsModulesFromModuleFinder(
               importPath: packageName,
               variableName: isSearch ? name : variableName,
               hasNamedExports: !isDefault,
+              isType,
             });
           }
 
           return JsModule.construct({
             hasNamedExports: !isDefault,
+            isType,
             relativeFilePath: path,
             stripFileExtensions: config.get('stripFileExtensions', {
               pathToImportedModule: path,


### PR DESCRIPTION
I hope I didn't forget anything, but it seems fine.
Indeed the case where one wants to export a class as a type, for instance, is not supported.
I mean, given an
`export default class TheClass { /* ... */ }`
you can't get
`import type TheClass from 'Module'`
because importjs would have to ask you each time how you want to import that class as.

Feel free to edit anything to your needs, or ask me to do so.
