### PR TITLE
Update babel-preset-airbnb 2.2.3 -> 2.3.3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,9 @@
 {
-  "presets": ["airbnb"],
+  "presets": [["airbnb", {
+    "targets": {
+      "node": 4
+    }
+  }]],
   "plugins": [
     "add-module-exports",
     "transform-flow-strip-types",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "babel-preset-airbnb": "^2.2.3",
+    "babel-preset-airbnb": "^2.3.3",
     "deasync": "^0.1.9",
     "eslint": "^3.16.1",
     "eslint-config-airbnb-base": "^11.1.0",


### PR DESCRIPTION
The main change here is the preset now uses babel-preset-env under the
hood. This allows us to produce a build that targets the minimum version
of node that we support. Since we run our tests starting at node 4 in
travis, this is what I set it to for now.