### PR TITLE
Add sortImports to known config options

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -101,6 +101,7 @@ const KNOWN_CONFIGURATION_OPTIONS = [
   'moduleNameFormatter',
   'moduleSideEffectImports',
   'namedExports',
+  'sortImports',
   'stripFileExtensions',
   'tab',
   'useRelativePaths',


### PR DESCRIPTION
I forgot something important X_X. It still works fine, but gives a warning