### PR TITLE
Improve messaging for added imports

### DIFF
--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -22,9 +22,9 @@ function fixImportsMessage(
   const firstRemoved = removedItems.values().next().value;
 
   if (addedItems.size === 1 && firstAdded) {
-    messageParts.push(`Imported \`${firstAdded}\`.`);
+    messageParts.push(`Imported ${firstAdded}`);
   } else if (addedItems.size) {
-    messageParts.push(`Added ${addedItems.size} imports.`);
+    messageParts.push(`Added ${addedItems.size} imports`);
   }
 
   if (removedItems.size === 1 && firstRemoved) {
@@ -36,7 +36,7 @@ function fixImportsMessage(
   if (messageParts.length === 0) {
     return undefined;
   }
-  return messageParts.join(' ');
+  return messageParts.join('. ');
 }
 
 export default class Importer {
@@ -95,14 +95,10 @@ export default class Importer {
             return;
           }
 
-          const jsModuleName = jsModule.displayName();
-          if (jsModule.hasNamedExports) {
-            this.message(
-              `Imported \`${variableName}\` from \`${jsModuleName}\``,
-            );
-          } else {
-            this.message(`Imported \`${jsModuleName}\``);
-          }
+          const imported = jsModule.hasNamedExports ?
+            `{ ${variableName} }` : variableName;
+
+          this.message(`Imported ${imported} from '${jsModule.importPath}'`);
 
           const oldImports = this.findCurrentImports();
           const importStatement = jsModule.toImportStatement(this.config);
@@ -206,7 +202,9 @@ export default class Importer {
             if (!jsModule) {
               return;
             }
-            addedItems.add(jsModule.variableName);
+            const imported = jsModule.hasNamedExports ?
+              `{ ${jsModule.variableName} }` : jsModule.variableName;
+            addedItems.add(`${imported} from '${jsModule.importPath}'`);
             newImports.push(jsModule.toImportStatement(this.config));
           });
 
@@ -481,7 +479,7 @@ export default class Importer {
       if (importStatements.size() > sizeBefore) {
         // The number of imports changed as part of adding the side-effect
         // import. This means that the import wasn't previously there.
-        addedImports.push(path);
+        addedImports.push(`'${path}'`);
       }
     });
     return addedImports;

--- a/lib/JsModule.js
+++ b/lib/JsModule.js
@@ -4,9 +4,9 @@ import path from 'path';
 
 import Configuration from './Configuration';
 import ImportStatement from './ImportStatement';
+import forwardSlashes from './forwardSlashes';
 import requireResolve from './requireResolve';
 import resolveImportPathAndMain from './resolveImportPathAndMain';
-import forwardSlashes from './forwardSlashes';
 
 // TODO figure out a more holistic solution than stripping node_modules
 function stripNodeModules(path: string): string {
@@ -23,7 +23,6 @@ export default class JsModule {
   isType: boolean;
   importPath: string;
   filePath: string;
-  mainFile: ?string;
   variableName: string;
   workingDirectory: string;
 
@@ -79,7 +78,6 @@ export default class JsModule {
     }
 
     jsModule.importPath = importPath;
-    jsModule.mainFile = mainFile;
     jsModule.hasNamedExports = hasNamedExports;
     jsModule.isType = isType;
     jsModule.variableName = variableName;
@@ -124,15 +122,6 @@ export default class JsModule {
     }
 
     this.importPath = importPath;
-  }
-
-  displayName(): string {
-    // TODO figure out a more holistic solution than stripping node_modules
-    const parts = [stripNodeModules(this.importPath)];
-    if (this.mainFile) {
-      parts.push(` (main: ${this.mainFile})`);
-    }
-    return parts.join('');
   }
 
   resolvedFilePath(

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -203,7 +203,7 @@ foo
 
       it('displays a message about the imported module', () => {
         subject();
-        expect(result.messages).toEqual(['Imported `./bar/foo`']);
+        expect(result.messages).toEqual(["Imported foo from './bar/foo'"]);
       });
 
       describe('when that import is already imported', () => {
@@ -771,7 +771,7 @@ foo
           it('displays a message about the imported module', () => {
             subject();
             expect(result.messages).toEqual([
-              'Imported `./Foo (main: index.jsx)`',
+              "Imported foo from './Foo'",
             ]);
           });
 
@@ -860,7 +860,7 @@ fooBar
 
           it('displays a message about the imported module', () => {
             subject();
-            expect(result.messages).toEqual(['Imported `foo-bar`']);
+            expect(result.messages).toEqual(["Imported fooBar from 'foo-bar'"]);
           });
 
           describe('when there is an exclude', () => {
@@ -1575,7 +1575,7 @@ memoize
           it('displays a message about the imported module', () => {
             subject();
             expect(result.messages).toEqual([
-              'Imported `memoize` from `underscore`',
+              "Imported { memoize } from 'underscore'",
             ]);
           });
 
@@ -2422,7 +2422,7 @@ foo();
 
       it('displays a message', () => {
         subject();
-        expect(result.messages).toEqual(['Imported `foo`.']);
+        expect(result.messages).toEqual(["Imported foo from './bar/foo'"]);
       });
 
       describe('when there is whitespace at the top', () => {
@@ -2476,7 +2476,7 @@ foo();
 
           it('displays a message', () => {
             subject();
-            expect(result.messages).toEqual(['Imported `foo`.']);
+            expect(result.messages).toEqual(["Imported foo from './bar/foo'"]);
           });
         },
       );
@@ -2510,7 +2510,7 @@ Baz
 
         it('displays a message', () => {
           subject();
-          expect(result.messages).toEqual(['Imported `Baz`.']);
+          expect(result.messages).toEqual(["Imported { Baz } from './star/foo'"]);
         });
       });
 
@@ -2556,7 +2556,7 @@ foo();
 
       it('displays a message', () => {
         subject();
-        expect(result.messages).toEqual(['Imported `surstromming`.']);
+        expect(result.messages).toEqual(["Imported 'surstromming'"]);
       });
 
       describe('when that import is already in the list', () => {
@@ -2602,7 +2602,7 @@ foo();
 
       it('displays a message', () => {
         subject();
-        expect(result.messages).toEqual(['Added 2 imports.']);
+        expect(result.messages).toEqual(['Added 2 imports']);
       });
     });
 
@@ -2625,7 +2625,7 @@ var a = foo + bar;
 
       it('displays a message', () => {
         subject();
-        expect(result.messages).toEqual(['Added 2 imports.']);
+        expect(result.messages).toEqual(['Added 2 imports']);
       });
     });
 
@@ -2652,7 +2652,7 @@ var b = bar + foo;
 
       it('displays a message with the right count', () => {
         subject();
-        expect(result.messages).toEqual(['Added 2 imports.']);
+        expect(result.messages).toEqual(['Added 2 imports']);
       });
     });
 
@@ -2681,7 +2681,7 @@ const foo = <Foo/>;
 
       it('displays a message', () => {
         subject();
-        expect(result.messages).toEqual(['Imported `Foo`.']);
+        expect(result.messages).toEqual(["Imported Foo from './bar/foo'"]);
       });
     });
 
@@ -2735,7 +2735,7 @@ var a = <span/>;
 
         it('displays a message', () => {
           subject();
-          expect(result.messages).toEqual(['Imported `React`.']);
+          expect(result.messages).toEqual(["Imported React from 'react'"]);
         });
       });
     });
@@ -2924,7 +2924,7 @@ foo
 
       it('displays a message', () => {
         subject();
-        expect(result.messages).toEqual(['Imported `foo`. Removed `bar`.']);
+        expect(result.messages).toEqual(["Imported foo from './bar/foo'. Removed `bar`."]);
       });
     });
 

--- a/lib/__tests__/JsModule-test.js
+++ b/lib/__tests__/JsModule-test.js
@@ -52,7 +52,6 @@ describe('JsModule', () => {
     });
 
     expect(jsModule.importPath).toEqual('lib/index.js/foo.js');
-    expect(jsModule.displayName()).toEqual('lib/index.js/foo.js');
   });
 
   it(

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -101,7 +101,7 @@ function dedupeAndSort(modules: Array<JsModule>): Array<JsModule> {
     sorted,
     (module: JsModule): string => module.importPath,
   );
-  return sortBy(uniques, (module: JsModule): string => module.displayName());
+  return sortBy(uniques, (module: JsModule): string => module.importPath);
 }
 
 const NON_PATH_ALIAS_PATTERN = /^[a-zA-Z0-9-_]+$/;


### PR DESCRIPTION
Inspired by 3a84a27, I'm changing the message displayed when importing a
module. From

  Imported `./Foo` (main: index.js)

To

  Imported foo from './Foo'

I believe this makes the message easier to parse/understand for a js
developer.