### PR TITLE
Fix sortImports link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The following configuration options are supported.
 - [`minimumVersion`](#minimumversion)
 - [`moduleNameFormatter`](#modulenameformatter)
 - [`namedExports`](#namedexports)
-- [`sortImports`](#sortImports)
+- [`sortImports`](#sortimports)
 - [`stripFileExtensions`](#stripfileextensions)
 - [`tab`](#tab)
 - [`useRelativePaths`](#userelativepaths)


### PR DESCRIPTION
It had a capital letter, causing the internal link to be broken.