### PR TITLE
Homonymous named/default export

### DIFF
--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -232,11 +232,18 @@ export default class Importer {
       const promises = variables.map((variableName: string): Promise<void> =>
         findJsModulesFor(this.config, variableName)
           .then((jsModules: Array<JsModule>) => {
-            const importPath = imports[variableName];
+            const importData = imports[variableName];
+            const dataIsObject = typeof importData === 'object';
+            const importPath = dataIsObject ? importData.importPath : importData;
+            const hasNamedExports = dataIsObject ? importData.isNamedExport : undefined;
+
             const foundModule = jsModules.find(
               (jsModule: JsModule): boolean =>
-                jsModule.importPath === importPath,
+                jsModule.importPath === importPath &&
+                (hasNamedExports === undefined ||
+                  jsModule.hasNamedExports === hasNamedExports),
             );
+
             if (foundModule) {
               newImports.push(foundModule.toImportStatement(this.config));
             } else {
@@ -244,6 +251,7 @@ export default class Importer {
                 new JsModule({
                   importPath,
                   variableName,
+                  hasNamedExports,
                 }).toImportStatement(this.config),
               );
             }
@@ -410,13 +418,17 @@ export default class Importer {
       displayName: jsModule
         .toImportStatement(this.config)
         .toImportStrings(Infinity, '  ')[0],
-      importPath: jsModule.importPath,
-      filePath: jsModule.resolvedFilePath(
-        this.pathToCurrentFile,
-        this.workingDirectory,
-      ),
-    })).sort((a: JsModule, b: JsModule): number =>
-      countSeparators(a.importPath) - countSeparators(b.importPath));
+      importPath: jsModule.importPath, // backward compatibility
+      data: {
+        importPath: jsModule.importPath,
+        filePath: jsModule.resolvedFilePath(
+          this.pathToCurrentFile,
+          this.workingDirectory,
+        ),
+        isNamedExport: jsModule.hasNamedExports,
+      },
+    })).sort((a: Object, b: Object): number =>
+      countSeparators(a.data.importPath) - countSeparators(b.data.importPath));
 
     return undefined;
   }

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1154,6 +1154,39 @@ foo
       });
     });
 
+    describe('when there is an export named as the module', () => {
+      beforeEach(() => {
+        existingFiles = ['bar/foo.js'];
+        readFile.mockImplementation(() => Promise.resolve(`
+          export { foo };
+          export default function() {};
+        `));
+      });
+
+      it('has no messages', () => {
+        subject();
+        expect(result.messages).toEqual([]);
+      });
+
+      it('records the alternatives to choose from', () => {
+        subject();
+        expect(result.unresolvedImports).toEqual({
+          foo: [
+            {
+              displayName: "import foo from './bar/foo';",
+              filePath: './bar/foo.js',
+              importPath: './bar/foo',
+            },
+            {
+              displayName: "import { foo } from './bar/foo';",
+              filePath: './bar/foo.js',
+              importPath: './bar/foo',
+            },
+          ],
+        });
+      });
+    });
+
     describe('importing a module with a package.json file', () => {
       beforeEach(() => {
         existingFiles = ['Foo/package.json', 'Foo/build/main.js'];

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1111,18 +1111,30 @@ foo
             foo: [
               {
                 displayName: "import foo from './bar/foo';",
-                filePath: './bar/foo.jsx',
                 importPath: './bar/foo',
+                data: {
+                  filePath: './bar/foo.jsx',
+                  importPath: './bar/foo',
+                  isNamedExport: false,
+                },
               },
               {
                 displayName: "import foo from './zoo/foo';",
-                filePath: './zoo/foo.js',
                 importPath: './zoo/foo',
+                data: {
+                  filePath: './zoo/foo.js',
+                  importPath: './zoo/foo',
+                  isNamedExport: false,
+                },
               },
               {
                 displayName: "import foo from './zoo/goo/Foo';",
-                filePath: 'zoo/goo/Foo/index.js',
                 importPath: './zoo/goo/Foo',
+                data: {
+                  filePath: 'zoo/goo/Foo/index.js',
+                  importPath: './zoo/goo/Foo',
+                  isNamedExport: false,
+                },
               },
             ],
           });
@@ -1140,13 +1152,21 @@ foo
             foo: [
               {
                 displayName: "import foo from './bar/foo';",
-                filePath: './bar/foo.jsx',
                 importPath: './bar/foo',
+                data: {
+                  filePath: './bar/foo.jsx',
+                  importPath: './bar/foo',
+                  isNamedExport: false,
+                },
               },
               {
                 displayName: "import foo from './zoo/goo/Foo';",
-                filePath: 'zoo/goo/Foo/index.js',
                 importPath: './zoo/goo/Foo',
+                data: {
+                  filePath: 'zoo/goo/Foo/index.js',
+                  importPath: './zoo/goo/Foo',
+                  isNamedExport: false,
+                },
               },
             ],
           });
@@ -1174,13 +1194,21 @@ foo
           foo: [
             {
               displayName: "import foo from './bar/foo';",
-              filePath: './bar/foo.js',
               importPath: './bar/foo',
+              data: {
+                filePath: './bar/foo.js',
+                importPath: './bar/foo',
+                isNamedExport: false,
+              },
             },
             {
               displayName: "import { foo } from './bar/foo';",
-              filePath: './bar/foo.js',
               importPath: './bar/foo',
+              data: {
+                filePath: './bar/foo.js',
+                importPath: './bar/foo',
+                isNamedExport: true,
+              },
             },
           ],
         });
@@ -2349,6 +2377,53 @@ foo; bar;
 
       it('displays a message', () => {
         expect(result.messages).toEqual(['Added 2 imports']);
+      });
+    });
+
+    describe('when adding one import with additional data', () => {
+      beforeEach(() => {
+        text = 'foo';
+        existingFiles = ['./star/foo.js'];
+        resolvedImports = {
+          foo: {
+            importPath: './star/foo',
+            isNamedExport: false,
+          },
+        };
+      });
+
+      it('adds import based on variable name and import path', () => {
+        expect(subject()).toEqual(
+          `
+import foo from './star/foo';
+
+foo
+        `.trim(),
+        );
+      });
+
+      it('displays a message', () => {
+        subject();
+        expect(result.messages).toEqual(['Added import for `foo`']);
+      });
+
+      describe('when the resolved import exists also as a named', () => {
+        beforeEach(() => {
+          readFile.mockImplementation(() => Promise.resolve(`
+            export { foo };
+            export default function() {};
+          `));
+        });
+
+        it('adds import based on resolved data provided', () => {
+          expect(subject()).toEqual(
+            `
+import foo from './star/foo';
+
+foo
+          `.trim(),
+          );
+        });
       });
     });
   });

--- a/lib/__tests__/findJsModulesFor-test.js
+++ b/lib/__tests__/findJsModulesFor-test.js
@@ -2,8 +2,9 @@ import path from 'path';
 
 import Configuration from '../Configuration';
 import FileUtils from '../FileUtils';
+import JsModule from '../JsModule';
 import ModuleFinder from '../ModuleFinder';
-import findJsModulesFor from '../findJsModulesFor';
+import findJsModulesFor, { dedupeAndSort } from '../findJsModulesFor';
 
 jest.mock('../ModuleFinder');
 jest.mock('../FileUtils');
@@ -36,4 +37,21 @@ describe('when a matching module is excluded', () => {
   ).then((jsModules) => {
     expect(jsModules.length).toEqual(0);
   }));
+});
+
+describe('when matching to an array of various modules', () => {
+  const modules = [
+    new JsModule({ importPath: './foo/bar', variableName: 'bar', hasNamedExports: true }),
+    new JsModule({ importPath: './foo/bar', variableName: 'bar', hasNamedExports: false }),
+    new JsModule({ importPath: './bar', variableName: 'bar', hasNamedExports: false }),
+    new JsModule({ importPath: './bar', variableName: 'Bar', hasNamedExports: false }),
+  ];
+
+  it('dedupes and sorts', () => {
+    expect(dedupeAndSort(modules)).toEqual([
+      new JsModule({ importPath: './bar', variableName: 'bar', hasNamedExports: false }),
+      new JsModule({ importPath: './foo/bar', variableName: 'bar', hasNamedExports: false }),
+      new JsModule({ importPath: './foo/bar', variableName: 'bar', hasNamedExports: true }),
+    ]);
+  });
 });

--- a/lib/findJsModulesFor.js
+++ b/lib/findJsModulesFor.js
@@ -90,7 +90,7 @@ function findJsModulesFromModuleFinder(
   });
 }
 
-function dedupeAndSort(modules: Array<JsModule>): Array<JsModule> {
+export function dedupeAndSort(modules: Array<JsModule>): Array<JsModule> {
   // We might end up having duplicate modules here.  In order to dedupe
   // these, we remove the module with the longest path
   const sorted = sortBy(
@@ -99,9 +99,12 @@ function dedupeAndSort(modules: Array<JsModule>): Array<JsModule> {
   );
   const uniques = uniqBy(
     sorted,
-    (module: JsModule): string => module.importPath,
+    // Default export and named export with same name from the same module are not considered dupes
+    (module: JsModule): string => [module.importPath, module.hasNamedExports].join(),
   );
-  return sortBy(uniques, (module: JsModule): string => module.importPath);
+  // Sorting by path, but with default exports before named exports
+  return sortBy(uniques, (module: JsModule): string =>
+    [module.importPath, module.hasNamedExports ? 1 : 0].join());
 }
 
 const NON_PATH_ALIAS_PATTERN = /^[a-zA-Z0-9-_]+$/;


### PR DESCRIPTION
Ref: https://github.com/Galooshi/import-js/issues/445

To begin with, homonymous named and default imports are no longer trimmed down by `dedupeAndSort`, and the default import is placed before the named one in the list (up for debate).

Then, as you suggested, a `data` object is passed down with `unresolvedImports` so options can be differentiated.

`addImports()` is now accounting for this `data` object (still being backward compatible when receiving just a `importPath` string), and for instance uses `isNamedExport` property to return the right resolved import.

For further reference, just taking the case of the atom add-on, we'd have to modify this code:
```
askView.deferred
.then((resolved) => {
  const add = {};
  // add[word] = resolved.importPath;
  add[word] = resolved.data;
  addImports(add);
})
```