### PR TITLE
Make `goto` find more file paths

### DIFF
--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -1,6 +1,7 @@
 // @flow
 import path from 'path';
-import fs from 'fs';
+
+import requireRelative from 'require-relative';
 
 import CommandLineEditor from './CommandLineEditor';
 import Configuration from './Configuration';
@@ -38,6 +39,27 @@ function fixImportsMessage(
     return undefined;
   }
   return messageParts.join('. ');
+}
+
+function findFilePathFromImports(
+  imports: ImportStatements,
+  dirname: string,
+  variableName: string,
+): ?string {
+  // eslint-disable-next-line no-restricted-syntax
+  const importStatement = imports.find((is: ImportStatement): boolean =>
+    is.hasVariable(variableName));
+
+  if (!importStatement) {
+    return undefined;
+  }
+
+  try {
+    return requireRelative.resolve(importStatement.path, dirname);
+  } catch (e) {
+    // it's expected that we can't resolve certain paths.
+  }
+  return undefined;
 }
 
 export default class Importer {
@@ -129,23 +151,23 @@ export default class Importer {
   }
 
   goto(variableName: string): Promise<Object> {
+    const { imports } = this.findCurrentImports();
+    const filePath = findFilePathFromImports(
+      imports,
+      path.dirname(this.pathToCurrentFile),
+      variableName,
+    );
+    if (filePath) {
+      return Promise.resolve({
+        goto: filePath,
+        ...this.results(),
+      });
+    }
+
     return new Promise((resolve: Function, reject: Function) => {
       findJsModulesFor(this.config, variableName)
         .then((jsModules: Array<JsModule>) => {
-          let jsModule = this.resolveModuleUsingCurrentImports(
-            jsModules,
-            variableName,
-          );
-
-          if (!jsModule) {
-            // If the module couldn't be resolved using existing imports, we just
-            // grab the first one. This isn't ideal if there are multiple matches,
-            // but it's rare that we end up here, and falling back to the first
-            // one simplifies things.
-            jsModule = jsModules[0];
-          }
-
-          if (!jsModule) {
+          if (!jsModules.length) {
             // The current word is not mappable to one of the JS modules that we
             // found. This can happen if the user does not select one from the list.
             // We have nothing to go to, so we return early.
@@ -154,28 +176,10 @@ export default class Importer {
             return;
           }
 
-          let filePath = jsModule.resolvedFilePath(
+          const filePath = jsModules[0].resolvedFilePath(
             this.pathToCurrentFile,
             this.workingDirectory,
           );
-
-          if (path.extname(filePath) === '') {
-            try {
-              fs.accessSync(filePath);
-            } catch (e) {
-              const basename = path.basename(filePath);
-              const dirname = path.dirname(filePath);
-              const files = fs.readdirSync(dirname);
-              const match = files
-                .find((file: string): boolean =>
-                  basename === path.basename(file, path.extname(file)));
-
-              if (match) {
-                filePath = `${dirname}/${match}`;
-              }
-            }
-          }
-
           const results = this.results();
           results.goto = path.isAbsolute(filePath)
             ? filePath

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import deasync from 'deasync';
+import requireRelative from 'require-relative';
 
 import FileUtils from '../FileUtils';
 import Importer from '../Importer';
@@ -9,6 +10,7 @@ import normalizePath from '../normalizePath';
 import readFile from '../readFile';
 import requireResolve from '../requireResolve';
 
+jest.mock('require-relative');
 jest.mock('../FileUtils');
 jest.mock('../requireResolve');
 jest.mock('../readFile');
@@ -3387,6 +3389,12 @@ foo
         describe('matching a package dependency', () => {
           beforeEach(() => {
             packageDependencies = ['some-package'];
+            requireRelative.resolve.mockImplementation(() =>
+              path.join(
+                process.cwd(),
+                'node_modules/some-package/some-package-main.jsx',
+              ),
+            );
           });
 
           it('opens the package main file', () => {
@@ -3465,6 +3473,12 @@ import foo from './car/foo';
 
 foo
             `.trim();
+            requireRelative.resolve.mockImplementation(() =>
+              path.join(
+                process.cwd(),
+                'car/foo.jsx',
+              ),
+            );
           });
 
           it('opens the file', () => {
@@ -3475,7 +3489,7 @@ foo
             beforeEach(() => {
               text = `
 import bar from './foo/bar';
-import foo from './bar/foo';
+import foo from './car/foo';
 import foobar from './bar/foobar';
 
 foo
@@ -3484,7 +3498,7 @@ foo
 
             it('opens the file', () => {
               expect(subject()).toEqual(
-                path.join(process.cwd(), 'bar/foo.jsx'),
+                path.join(process.cwd(), 'car/foo.jsx'),
               );
             });
           });
@@ -3493,7 +3507,7 @@ foo
         describe('as an import where the path has been modified', () => {
           beforeEach(() => {
             configuration.moduleNameFormatter = ({ moduleName }) =>
-              moduleName.replace(/^\.\/bar\//, '');
+              moduleName.replace(/^\.\/car\//, '');
             text = `
 import foo from 'foo';
 
@@ -3502,21 +3516,21 @@ foo
           });
 
           it('opens the file', () => {
-            expect(subject()).toEqual(path.join(process.cwd(), 'bar/foo.jsx'));
+            expect(subject()).toEqual(path.join(process.cwd(), 'car/foo.jsx'));
           });
         });
 
         describe('as a named import', () => {
           beforeEach(() => {
             text = `
-import { foo } from './bar/foo';
+import { foo } from './car/foo';
 
 foo
             `.trim();
           });
 
           it('opens the file', () => {
-            expect(subject()).toEqual(path.join(process.cwd(), 'bar/foo.jsx'));
+            expect(subject()).toEqual(path.join(process.cwd(), 'car/foo.jsx'));
           });
         });
       });


### PR DESCRIPTION
Before when running `goto`, we would ask the ModuleFinder for matches on
the variable name. We would then take that list and map it against
current imports. This only worked in cases where the file you were going
to was already in the index. When the file for some reason wasn't in the
index, goto wouldn't work.

To make things a little more robust, I'm changing the ordering of things
a bit. Instead of asking the index first, we look through current
imports and try to resolve the module name for the matching import
statement. If that fails (the variable isn't yet imported or the path
couldn't be resolved), we continue to ask the ModuleFinder for matches.

The new behavior is a little bit more robust, and slightly faster.

The changes made in #457 inspired me to dig a little deeper through
`goto` which led up to this commit.