### PR TITLE
Ignore packages labeled "isRoot": false

### DIFF
--- a/lib/__tests__/findProjectRoot-test.js
+++ b/lib/__tests__/findProjectRoot-test.js
@@ -7,17 +7,24 @@ jest.mock('fs');
 
 afterEach(() => fs.__reset());
 
+const normalPackageJsonContents = `{
+  "name": "some-package",
+  "dependencies": {
+
+  }
+}`;
+
 it('finds the right folders', () => {
   // FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
-  fs.__setFile(path.join(path.resolve('/'), 'foo', 'package.json'));
-  fs.__setFile(path.join(path.resolve('/'), 'foo', 'bar', 'package.json'));
+  fs.__setFile(path.join(path.resolve('/'), 'foo', 'package.json'), normalPackageJsonContents);
+  fs.__setFile(path.join(path.resolve('/'), 'foo', 'bar', 'package.json'), normalPackageJsonContents);
   expect(findProjectRoot(path.join(path.resolve('/'), 'foo', 'bar', 'baz.js')))
     .toEqual(path.join(path.resolve('/'), 'foo', 'bar'));
 });
 
 it('treats package folders as roots', () => {
-  fs.__setFile(path.join(path.resolve('/'), 'foo', 'package.json'));
-  fs.__setFile(path.join(path.resolve('/'), 'foo', 'node_modules', 'bar', 'package.json'));
+  fs.__setFile(path.join(path.resolve('/'), 'foo', 'package.json'), normalPackageJsonContents);
+  fs.__setFile(path.join(path.resolve('/'), 'foo', 'node_modules', 'bar', 'package.json'), normalPackageJsonContents);
   // expect(findProjectRoot('/foo/node_modules/bar/baz/gaz.js')).toEqual(
   expect(findProjectRoot(path.join(path.resolve('/'), 'foo', 'node_modules', 'bar', 'baz', 'gaz.js')))
     .toEqual(path.join(path.resolve('/'), 'foo', 'node_modules', 'bar'));
@@ -28,7 +35,19 @@ it('throws if it can not find a folder', () => {
 });
 
 it('works for relative paths as well', () => {
-  fs.__setFile(path.join(process.cwd(), path.join('foo', 'package.json')));
+  fs.__setFile(path.join(process.cwd(), path.join('foo', 'package.json')), normalPackageJsonContents);
   expect(findProjectRoot(path.join('foo', 'bar', 'baz.js'))).toEqual(path.join(process.cwd(), 'foo'));
   expect(findProjectRoot(path.join('.', 'foo', 'bar', 'baz.js'))).toEqual(path.join(process.cwd(), 'foo'));
+});
+
+it('ignores directories in which the package.json specifies "isRoot": false', () => {
+  fs.__setFile(path.join(path.resolve('/'), 'foo', 'package.json'), normalPackageJsonContents);
+  fs.__setFile(path.join(path.resolve('/'), 'foo', 'bar', 'package.json'), `{
+    "name": "not-root",
+    "dependencies": {
+
+    },
+    "isRoot": false
+  }`);
+  expect(findProjectRoot(path.join('/', 'foo', 'bar', 'baz.js'))).toEqual(path.join(path.resolve('/'), 'foo'));
 });

--- a/lib/findProjectRoot.js
+++ b/lib/findProjectRoot.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import FileUtils from './FileUtils';
+
 const isWinDriveRoot = /^[A-Z]:\\$/;
 
 function findRecursive(directory) {
@@ -11,7 +13,11 @@ function findRecursive(directory) {
   const pathToPackageJson = path.join(directory, 'package.json');
 
   if (fs.existsSync(pathToPackageJson)) {
-    return directory;
+    const packageDescription = FileUtils.readJsonFile(pathToPackageJson);
+
+    if (!('isRoot' in packageDescription) || packageDescription.isRoot) {
+      return directory;
+    }
   }
 
   return findRecursive(path.dirname(directory));


### PR DESCRIPTION
This was the approach I considered cleanest, but I'm definitely willing to implement something others might consider cleaner. I figured putting the root in the config would mean you'd have to make multiple configs, and that would create a lot of ambiguity.