### PR TITLE
Allow overwriting of merged config options (eg globals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The following configuration options are supported.
 - [`stripFileExtensions`](#stripfileextensions)
 - [`tab`](#tab)
 - [`useRelativePaths`](#userelativepaths)
+- [`mergableOptions`](#mergableOptions)
 
 ### `excludes`
 
@@ -467,6 +468,51 @@ logLevel: 'debug'
 The logfile is written to "importjs.log" in your operating system's default
 directory for temporary files. You can get the path to the log file by running
 `importjsd logpath`.
+
+### `mergableOptions`
+
+A dictionary of Options that be merged with defaults and values provided by an [`environment`](#environments). This can be used to overwrite options provided by environments. Defaults to:
+
+```javascript
+mergableOptions: {
+  aliases: true,
+  coreModules: true,
+  namedExports: true,
+  globals: true,
+}
+```
+
+Note: the `mergableOptions` option will always be merged and will be ignored if
+included in a user config.
+
+To disable merging a particular option or set of options, set the key to
+`false`:
+
+```javascript
+mergableOptions: {
+  globals: false
+}
+```
+
+For example, if you are using the `meteor` environment but want to explicitly
+import modules which are provided as globals, you can use this setting to
+overwrite the environment globals.
+
+```javascript
+const globals = require('globals');
+module.exports = {
+  environments: ['meteor', 'node'],
+  mergableOptions: {
+    globals: false // Overwrite globals
+  },
+  globals: [
+    // Add the globals you want back in
+    ...Object.keys(globals.builtin), // include javascript builtins
+    ...Object.keys(globals.node), // include node globals
+    'Package', 'Npm' // Include meteor globals for `package.js` files
+  ]
+}
+```
 
 ## Dynamic configuration
 

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -67,18 +67,17 @@ const DEFAULT_CONFIG = {
       config.workingDirectory,
       config.get('importDevDependencies'),
     ),
+  // Default configuration options, and options inherited from environment
+  // configuration are overridden if they appear in user config. Some options,
+  // however, get merged with the parent configuration. This list specifies which
+  // ones are merged.
+  mergableOptions: {
+    aliases: true,
+    coreModules: true,
+    namedExports: true,
+    globals: true,
+  },
 };
-
-// Default configuration options, and options inherited from environment
-// configuration are overridden if they appear in user config. Some options,
-// however, get merged with the parent configuration. This list specifies which
-// ones are merged.
-const MERGABLE_CONFIG_OPTIONS = [
-  'aliases',
-  'coreModules',
-  'namedExports',
-  'globals',
-];
 
 const KNOWN_CONFIGURATION_OPTIONS = [
   'aliases',
@@ -103,6 +102,7 @@ const KNOWN_CONFIGURATION_OPTIONS = [
   'stripFileExtensions',
   'tab',
   'useRelativePaths',
+  'mergableOptions',
 ];
 
 const ENVIRONMENTS = {
@@ -143,14 +143,19 @@ function mergedValue(values: Array<any>, key: string, options: Object): any {
     if (typeof value === 'function') {
       value = value(options);
     }
-    if (MERGABLE_CONFIG_OPTIONS.indexOf(key) === -1) {
-      // This key shouldn't be merged
-      return value;
+    // Prevent an endless loop of mergedValue calls
+    // The mergableOptions key will get merged by skipping this check
+    if (key !== 'mergableOptions') {
+      const mergableOptions = options.config.get('mergableOptions');
+      if (mergableOptions[key] !== true) {
+        // This key shouldn't be merged
+        return value;
+      }
     }
     if (Array.isArray(value)) {
       mergedResult = (mergedResult || []).concat(value);
     } else if (typeof value === 'object') {
-      mergedResult = Object.assign(mergedResult || {}, value);
+      mergedResult = Object.assign({}, value, mergedResult || {});
     } else {
       // Neither an object nor an array, so we just return the first value we
       // have.
@@ -190,7 +195,15 @@ export default class Configuration {
 
       // Add configurations for the environments specified in the user config
       // file.
-      (this.get('environments') || []).forEach((environment: string) => {
+      // Don't use `this.get` because the config hasn't finished initalizing.
+      // Use userConfig instead since it's the only one declared
+      if (typeof userConfig.environments === 'function') {
+        userConfig.environments = userConfig.environments({
+          config: this,
+          pathToCurrentFile: this.pathToCurrentFile,
+        });
+      }
+      (userConfig.environments || []).forEach((environment: string) => {
         const envConfig = ENVIRONMENTS[environment];
         if (envConfig) {
           this.configs.push(envConfig);

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -105,6 +105,10 @@ const KNOWN_CONFIGURATION_OPTIONS = [
   'mergableOptions',
 ];
 
+const DEPRECATED_CONFIGURATION_OPTIONS = [
+  'namedExports',
+];
+
 const ENVIRONMENTS = {
   node: nodeEnvironment,
   meteor: meteorEnvironment,
@@ -114,8 +118,21 @@ function checkForUnknownConfiguration(config: Object): Array<string> {
   const messages = [];
 
   Object.keys(config).forEach((option: string) => {
-    if (KNOWN_CONFIGURATION_OPTIONS.indexOf(option) === -1) {
+    if (!KNOWN_CONFIGURATION_OPTIONS.includes(option)) {
       messages.push(`Unknown configuration: \`${option}\``);
+    }
+  });
+
+  return messages;
+}
+
+function checkForDeprecatedConfiguration(config: Object): Array<string> {
+  const messages = [];
+
+  Object.keys(config).forEach((option: string) => {
+    if (DEPRECATED_CONFIGURATION_OPTIONS.includes(option)) {
+      messages.push(`Using ${option} to configure ImportJS is deprecated and ` +
+      'will go away in a future version.');
     }
   });
 
@@ -192,6 +209,7 @@ export default class Configuration {
     if (userConfig) {
       this.configs.push(userConfig);
       this.messages.push(...checkForUnknownConfiguration(userConfig));
+      this.messages.push(...checkForDeprecatedConfiguration(userConfig));
 
       // Add configurations for the environments specified in the user config
       // file.

--- a/lib/__tests__/Configuration-test.js
+++ b/lib/__tests__/Configuration-test.js
@@ -4,6 +4,8 @@ import os from 'os';
 import path from 'path';
 import requireRelative from 'require-relative';
 
+import globals from 'globals';
+
 import Configuration from '../Configuration';
 import FileUtils from '../FileUtils';
 import version from '../version';
@@ -53,6 +55,21 @@ describe('Configuration', () => {
       const configuration = new Configuration();
       expect(configuration.get('aliases')).toEqual({});
       expect(configuration.get('declarationKeyword')).toEqual('import');
+      expect(configuration.get('groupImports')).toEqual(true);
+      expect(configuration.get('sortImports')).toEqual(true);
+      expect(configuration.get('importDevDependencies')).toEqual(false);
+      expect(configuration.get('importFunction')).toEqual('require');
+      expect(configuration.get('stripFileExtensions')).toEqual(['.js', '.jsx']);
+      expect(configuration.get('useRelativePaths')).toEqual(true);
+      expect(configuration.get('maxLineLength')).toEqual(80);
+      expect(configuration.get('tab')).toEqual('  ');
+      expect(configuration.get('logLevel')).toEqual('info');
+      expect(configuration.get('mergableOptions')).toEqual({
+        aliases: true,
+        coreModules: true,
+        namedExports: true,
+        globals: true,
+      });
     });
 
     describe('with a JSON configuration file', () => {
@@ -201,6 +218,24 @@ describe('Configuration', () => {
     });
   });
 
+  describe('#get aliases', () => {
+    it('returns an empty object', () => {
+      expect(new Configuration().get('aliases')).toEqual({});
+    });
+
+    describe('with a javascript configuration file', () => {
+      beforeEach(() => {
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+          aliases: { foo: 'bar' },
+        });
+      });
+
+      it('returns the configured value for the key', () => {
+        expect(new Configuration().get('aliases')).toEqual({ foo: 'bar' });
+      });
+    });
+  });
+
   describe('#get coreModules', () => {
     it('returns an empty array', () => {
       expect(new Configuration().get('coreModules')).toEqual([]);
@@ -232,6 +267,53 @@ describe('Configuration', () => {
           'meteor/templating',
           'meteor/tracker',
         ]);
+      });
+      describe('with user defined coreModules', () => {
+        beforeEach(() => {
+          FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+            environments: ['meteor'],
+            coreModules: ['FOO', 'bar'],
+          });
+        });
+
+        it('merges user and meteor core modules', () => {
+          expect(new Configuration().get('coreModules')).toEqual([
+            'FOO',
+            'bar',
+            'meteor/accounts-base',
+            'meteor/blaze',
+            'meteor/check',
+            'meteor/ddp-client',
+            'meteor/ddp-rate-limiter',
+            'meteor/ejson',
+            'meteor/email',
+            'meteor/http',
+            'meteor/check',
+            'meteor/meteor',
+            'meteor/mongo',
+            'meteor/random',
+            'meteor/reactive-var',
+            'meteor/session',
+            'meteor/templating',
+            'meteor/tracker',
+          ]);
+        });
+        describe('with mergableOptions.coreModules set to false', () => {
+          beforeEach(() => {
+            FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+              environments: ['meteor'],
+              coreModules: ['FOO', 'bar'],
+              mergableOptions: { coreModules: false },
+            });
+          });
+
+          it('returns only user coreModules', () => {
+            expect(new Configuration().get('coreModules')).toEqual([
+              'FOO',
+              'bar',
+            ]);
+          });
+        });
       });
     });
 
@@ -292,6 +374,120 @@ describe('Configuration', () => {
         const coreModules = new Configuration().get('coreModules');
         expect(coreModules).toContain('child_process');
         expect(coreModules).toContain('meteor/check');
+      });
+    });
+  });
+
+  describe('#get globals', () => {
+    it('returns javascript builtins', () => {
+      expect(new Configuration().get('globals')).toEqual(Object.keys(globals.builtin));
+    });
+
+    describe('with a javascript configuration file', () => {
+      beforeEach(() => {
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+          globals: ['FOO', 'Bar'],
+        });
+      });
+
+      it('returns the configured value merged with defaults', () => {
+        expect(new Configuration().get('globals')).toEqual([
+          'FOO',
+          'Bar',
+          ...Object.keys(globals.builtin),
+        ]);
+      });
+    });
+
+    describe('in a meteor environment', () => {
+      beforeEach(() => {
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+          environments: ['meteor'],
+        });
+      });
+
+      it('returns meteor globals', () => {
+        const ourGlobals = new Configuration().get('globals');
+        expect(ourGlobals).toEqual([
+          ...Object.keys(globals.builtin),
+          ...Object.keys(globals.meteor),
+        ]);
+        expect(ourGlobals).toContain('Meteor');
+        expect(ourGlobals).toContain('Package');
+      });
+      describe('with user defined globals', () => {
+        beforeEach(() => {
+          FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+            environments: ['meteor'],
+            globals: ['FOO', 'bar'],
+          });
+        });
+
+        it('merges user, meteor and default globals', () => {
+          expect(new Configuration().get('globals')).toEqual([
+            'FOO',
+            'bar',
+            ...Object.keys(globals.builtin),
+            ...Object.keys(globals.meteor),
+          ]);
+        });
+        describe('with mergableOptions.globals set to false', () => {
+          beforeEach(() => {
+            FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+              environments: ['meteor'],
+              globals: ['FOO', 'bar'],
+              mergableOptions: { globals: false },
+            });
+          });
+
+          it('returns only user globals', () => {
+            expect(new Configuration().get('globals')).toEqual([
+              'FOO',
+              'bar',
+            ]);
+          });
+        });
+      });
+    });
+
+    describe('in a node environment', () => {
+      beforeEach(() => {
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+          environments: ['node'],
+        });
+      });
+
+      it('returns node globals', () => {
+        const ourGlobals = new Configuration().get('globals');
+        expect(ourGlobals).toEqual([
+          ...Object.keys(globals.builtin),
+          ...Object.keys(globals.node),
+        ]);
+        expect(ourGlobals).toContain('process');
+        expect(ourGlobals).toContain('__dirname');
+        expect(ourGlobals).toContain('setImmediate');
+      });
+    });
+
+    describe('in multiple environments', () => {
+      beforeEach(() => {
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+          environments: ['node', 'meteor'],
+        });
+      });
+
+      it('returns globals all environments', () => {
+        const ourGlobals = new Configuration().get('globals');
+        expect(ourGlobals).toEqual([
+          ...Object.keys(globals.builtin),
+          ...Object.keys(globals.node),
+          ...Object.keys(globals.meteor),
+        ]);
+        expect(ourGlobals).toContain('Meteor');
+        expect(ourGlobals).toContain('Package');
+        expect(ourGlobals).toContain('process');
+        expect(ourGlobals).toContain('__dirname');
+        expect(ourGlobals).toContain('setImmediate');
       });
     });
   });
@@ -767,46 +963,94 @@ export { barbazCorge };
         return resolvedPath;
       });
     });
-
+    const expectedNamedExports = {
+      // These namedExports are the core ones that are always returned for Meteor
+      'meteor/accounts-base': [
+        'AccountsClient',
+        'Accounts',
+        'AccountsServer',
+      ],
+      'meteor/blaze': ['Blaze'],
+      'meteor/check': ['check', 'Match'],
+      'meteor/ddp-client': ['DDP'],
+      'meteor/ddp-rate-limiter': ['DDPRateLimiter'],
+      'meteor/ejson': ['EJSON'],
+      'meteor/email': ['Email'],
+      'meteor/http': ['HTTP'],
+      'meteor/meteor': ['Meteor'],
+      'meteor/mongo': ['Mongo'],
+      'meteor/random': ['Random'],
+      'meteor/reactive-var': ['ReactiveVar'],
+      'meteor/session': ['Session'],
+      'meteor/templating': ['Template'],
+      'meteor/tracker': ['Tracker'],
+      // These namedExports should be extracted from the Meteor metadata
+      'meteor/john:foo': ['foosball'],
+      'meteor/jane:bar': ['barsketball'],
+      'meteor/john:foobar': [
+        'foobarsball',
+        'foobarsballFunc',
+        'foobarQux',
+        'foobarQuux',
+        'foobarCorge',
+      ],
+      'meteor/jane:barbaz': [
+        'barbazsketball',
+        'barbazsketballFunc',
+        'barbazQux',
+        'barbazQuux',
+        'barbazCorge',
+      ],
+    };
     it('extracts namedExports and merges them into a single object', () => {
-      expect(new Configuration().get('namedExports')).toEqual({
-        // These namedExports are the core ones that are always returned for Meteor
-        'meteor/accounts-base': [
-          'AccountsClient',
-          'Accounts',
-          'AccountsServer',
-        ],
-        'meteor/blaze': ['Blaze'],
-        'meteor/check': ['check', 'Match'],
-        'meteor/ddp-client': ['DDP'],
-        'meteor/ddp-rate-limiter': ['DDPRateLimiter'],
-        'meteor/ejson': ['EJSON'],
-        'meteor/email': ['Email'],
-        'meteor/http': ['HTTP'],
-        'meteor/meteor': ['Meteor'],
-        'meteor/mongo': ['Mongo'],
-        'meteor/random': ['Random'],
-        'meteor/reactive-var': ['ReactiveVar'],
-        'meteor/session': ['Session'],
-        'meteor/templating': ['Template'],
-        'meteor/tracker': ['Tracker'],
-        // These namedExports should be extracted from the Meteor metadata
-        'meteor/john:foo': ['foosball'],
-        'meteor/jane:bar': ['barsketball'],
-        'meteor/john:foobar': [
-          'foobarsball',
-          'foobarsballFunc',
-          'foobarQux',
-          'foobarQuux',
-          'foobarCorge',
-        ],
-        'meteor/jane:barbaz': [
-          'barbazsketball',
-          'barbazsketballFunc',
-          'barbazQux',
-          'barbazQuux',
-          'barbazCorge',
-        ],
+      expect(new Configuration().get('namedExports')).toEqual(expectedNamedExports);
+    });
+
+    describe('with user defined namedExports', () => {
+      beforeEach(() => {
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+          environments: ['meteor'],
+          namedExports: {
+            'lib/utils': [
+              'escape',
+              'hasKey',
+            ],
+          },
+        });
+      });
+
+      it('merges user, meteor and found namedExports', () => {
+        expect(new Configuration().get('namedExports')).toEqual({
+          ...expectedNamedExports,
+          'lib/utils': [
+            'escape',
+            'hasKey',
+          ],
+        });
+      });
+    });
+
+    describe('with mergableOptions.namedExports set to false', () => {
+      beforeEach(() => {
+        FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
+          environments: ['meteor'],
+          namedExports: {
+            'lib/utils': [
+              'escape',
+              'hasKey',
+            ],
+          },
+          mergableOptions: { namedExports: false },
+        });
+      });
+
+      it('returns only user namedExports', () => {
+        expect(new Configuration().get('namedExports')).toEqual({
+          'lib/utils': [
+            'escape',
+            'hasKey',
+          ],
+        });
       });
     });
   });

--- a/lib/__tests__/Configuration-test.js
+++ b/lib/__tests__/Configuration-test.js
@@ -1019,6 +1019,14 @@ export { barbazCorge };
         });
       });
 
+      it('has a deprecation message', () => {
+        const configuration = new Configuration();
+        expect(configuration.messages).toEqual([
+          'Using namedExports to configure ImportJS is deprecated and will ' +
+          'go away in a future version.',
+        ]);
+      });
+
       it('merges user, meteor and found namedExports', () => {
         expect(new Configuration().get('namedExports')).toEqual({
           ...expectedNamedExports,

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -1513,9 +1513,7 @@ memoize
 
           it('displays a message about the imported module', () => {
             subject();
-            expect(result.messages).toEqual([
-              "Imported { memoize } from 'underscore'",
-            ]);
+            expect(result.messages).toContain("Imported { memoize } from 'underscore'");
           });
 
           describe('when the default import exists for the same module', () => {


### PR DESCRIPTION
Based on the issue #406 I've added the ability to overwrite options that are normally merged by adding a `mergeableOptions` object to user configs in `.importsjs.js`

Example from the config I use for Meteor projects
```
module.exports = {
    declarationKeyword: 'import',
    environments: ['meteor', 'node'],
    mergableOptions:{ globals: false },
    globals: [ ...Object.keys(globals.builtin), ...Object.keys(globals.node), 'Package', 'Npm' ],
    useRelativePaths: false,
};
```
Which now excludes the default globals from import-js and the environments, and adds the ones I want back in.

This PR is not complete, I haven't added any tests or docs for this feature yet. All existing tests pass. If this is a desired change I'll add test coverage and update docs

Is this a desired feature? And is this the right way to go about implementing it?