### PR TITLE
Dont rearrange modified imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The following configuration options are supported.
 - [`stripFileExtensions`](#stripfileextensions)
 - [`tab`](#tab)
 - [`useRelativePaths`](#userelativepaths)
-- [`mergableOptions`](#mergableOptions)
+- [`mergableOptions`](#mergableoptions)
 
 ### `excludes`
 

--- a/lib/ImportStatement.js
+++ b/lib/ImportStatement.js
@@ -216,8 +216,8 @@ export default class ImportStatement {
   }
 
   /**
-  * Merge another ImportStatement into this one.
-  */
+   * Merge another ImportStatement into this one.
+   */
   merge(importStatement: ImportStatement) {
     if (
       importStatement.defaultImport &&
@@ -347,7 +347,7 @@ export default class ImportStatement {
     }
 
     const tabJoined = named.join(`,\n${tab}`);
-    const namedMultiLine = `{\n${tab}${tabJoined}\n}`;
+    const namedMultiLine = `{\n${tab}${tabJoined},\n}`;
     return `${this.declarationKeyword || ''} ${prefix}${namedMultiLine} ${equals} ${value}`;
   }
 

--- a/lib/ImportStatement.js
+++ b/lib/ImportStatement.js
@@ -9,9 +9,9 @@ function equalsAndValue({
   importFunction,
   path,
 }: {
-    declarationKeyword: ?string,
-    importFunction: ?string,
-    path: string,
+  declarationKeyword: ?string,
+  importFunction: ?string,
+  path: string,
   }): Object {
   if (declarationKeyword === 'import') {
     return { equals: 'from', value: `'${path}';` };
@@ -35,6 +35,7 @@ export default class ImportStatement {
   namedImports: Array<Object>;
   areOnlyTypes: boolean; // true if namedImports are all 'type' imports
   originalImportString: ?string;
+  isChangedNamedImport: ?string;
   leadingContent: ?string;
   path: string;
 
@@ -48,21 +49,23 @@ export default class ImportStatement {
     namedImports = [],
     areOnlyTypes = false,
     originalImportString,
+    isChangedNamedImport = false,
     leadingContent,
     path,
   }: {
-      assignment?: ?string,
-      declarationKeyword?: ?string,
-      hasTypeKeyword?: ?boolean,
-      defaultImport?: ?string,
-      hasSideEffects: boolean,
-      importFunction?: ?string,
-      namedImports?: Array<Object>,
-      areOnlyTypes?: boolean,
-      originalImportString?: ?string,
-      leadingContent?: ?string,
-      path: string,
-    } = {}) {
+    assignment?: ?string,
+    declarationKeyword?: ?string,
+    hasTypeKeyword?: ?boolean,
+    defaultImport?: ?string,
+    hasSideEffects: boolean,
+    importFunction?: ?string,
+    namedImports?: Array<Object>,
+    areOnlyTypes?: boolean,
+    originalImportString?: ?string,
+    isChangedNamedImport?: ?boolean,
+    leadingContent?: ?string,
+    path: string,
+  } = {}) {
     this.assignment = assignment;
     this.declarationKeyword = declarationKeyword;
     this.hasTypeKeyword = hasTypeKeyword;
@@ -72,6 +75,7 @@ export default class ImportStatement {
     this.namedImports = namedImports;
     this.areOnlyTypes = areOnlyTypes;
     this.originalImportString = originalImportString;
+    this.isChangedNamedImport = isChangedNamedImport;
     this.leadingContent = leadingContent;
     this.path = path;
   }
@@ -139,7 +143,7 @@ export default class ImportStatement {
    *   existing import and it hasn't been altered since it was created.
    */
   isParsedAndUntouched(): boolean {
-    return !!this.originalImportString;
+    return !!this.originalImportString || this.isChangedNamedImport;
   }
 
   /**
@@ -164,12 +168,12 @@ export default class ImportStatement {
   }
 
   /**
-   * @return {Array<String>} Array of all variables that this ImportStatement
-   *   imports.
-   */
-  variables(): Array<string> {
-    return [this.defaultImport, ...this.localNames()].filter(Boolean);
-  }
+    * @return {Array<String>} Array of all variables that this ImportStatement
+    *   imports.
+    */
+    variables(): Array<string> {
+      return [this.defaultImport, ...this.localNames()].filter(Boolean);
+    }
 
   toImportStrings(maxLineLength: number, tab: string): Array<string> {
     const strings = this._importStrings(maxLineLength, tab);
@@ -212,134 +216,142 @@ export default class ImportStatement {
   }
 
   /**
-   * Merge another ImportStatement into this one.
-   */
-  merge(importStatement: ImportStatement) {
-    if (
+    * Merge another ImportStatement into this one.
+    */
+    merge(importStatement: ImportStatement) {
+      if (
       importStatement.defaultImport &&
-      this.defaultImport !== importStatement.defaultImport
+        this.defaultImport !== importStatement.defaultImport
     ) {
-      this.defaultImport = importStatement.defaultImport;
-      this._clearImportStringCache();
-    }
+        this.defaultImport = importStatement.defaultImport;
+        this._clearImportStringCache();
+      }
 
-    if (
-      importStatement.hasSideEffects &&
-      this.hasSideEffects !== importStatement.hasSideEffects
-    ) {
-      // If a module is ever thought to have side-effects, then assume it does.
-      this.hasSideEffects = true;
-      this._clearImportStringCache();
-    }
+      if (
+        importStatement.isChangedNamedImport &&
+        this.isChangedNamedImport !== importStatement.isChangedNamedImport
+      ) {
+        this.isChangedNamedImport = importStatement.isChangedNamedImport;
+        this._clearImportStringCache();
+      }
 
-    if (importStatement.hasNamedImports()) {
-      this.namedImports = this.namedImports || [];
-      const originalNamedImports = this.namedImports.slice(0); // clone array
+      if (
+        importStatement.hasSideEffects &&
+        this.hasSideEffects !== importStatement.hasSideEffects
+      ) {
+        // If a module is ever thought to have side-effects, then assume it does.
+        this.hasSideEffects = true;
+        this._clearImportStringCache();
+      }
 
-      let modified = false;
+      if (importStatement.hasNamedImports()) {
+        this.namedImports = this.namedImports || [];
+        const originalNamedImports = this.namedImports.slice(0); // clone array
 
-      importStatement.namedImports.forEach((named: Object) => {
-        const namedImport = originalNamedImports.find(({
-          localName,
-        }: {
-          localName: string,
-        }): boolean =>
-          localName === named.localName);
-        if (!namedImport) {
-          this.namedImports.push(named);
-          modified = true;
-          if (this.areOnlyTypes && !named.isType) {
-            this.areOnlyTypes = false;
+        let modified = false;
+
+        importStatement.namedImports.forEach((named: Object) => {
+          const namedImport = originalNamedImports.find(({
+            localName,
+          }: {
+            localName: string,
+          }): boolean =>
+            localName === named.localName);
+          if (!namedImport) {
+            this.namedImports.push(named);
+            modified = true;
+            if (this.areOnlyTypes && !named.isType) {
+              this.areOnlyTypes = false;
+            }
           }
-        }
-      });
-      if (modified) {
-        this.namedImports.sort((a: Object, b: Object): number => {
-          if (a.localName < b.localName) {
-            return -1;
-          }
-          if (a.localName > b.localName) {
-            return 1;
-          }
-          return 0;
         });
+        if (modified) {
+          this.namedImports.sort((a: Object, b: Object): number => {
+            if (a.localName < b.localName) {
+              return -1;
+            }
+            if (a.localName > b.localName) {
+              return 1;
+            }
+            return 0;
+          });
+          this._clearImportStringCache();
+        }
+      }
+
+      if (this.declarationKeyword !== importStatement.declarationKeyword) {
+        this.declarationKeyword = importStatement.declarationKeyword;
         this._clearImportStringCache();
       }
     }
 
-    if (this.declarationKeyword !== importStatement.declarationKeyword) {
-      this.declarationKeyword = importStatement.declarationKeyword;
-      this._clearImportStringCache();
-    }
-  }
-
-  _assignmentLessImportString(): string {
-    if (this.declarationKeyword === 'import') {
-      return `import '${this.path}';`;
-    }
-
-    return `${this.importFunction || 'require'}('${this.path}');`;
-  }
-
-  _defaultImportString(maxLineLength: number, tab: string): string {
-    const { equals, value } = equalsAndValue({
-      declarationKeyword: this.declarationKeyword,
-      importFunction: this.importFunction,
-      path: this.path,
-    });
-
-    const line = `${this.declarationKeyword || ''} ${this.defaultImport || ''} ${equals} ${value}`;
-    if (!isLineTooLong(line, maxLineLength)) {
-      return line;
-    }
-
-    return `${this.declarationKeyword || ''} ${this.defaultImport || ''} ${equals}\n${tab}${value}`;
-  }
-
-  _namedImportString(maxLineLength: number, tab: string): string {
-    const { equals, value } = equalsAndValue({
-      declarationKeyword: this.declarationKeyword,
-      importFunction: this.importFunction,
-      path: this.path,
-    });
-
-    let prefix = '';
-    if (this.declarationKeyword === 'import') {
-      if (this.defaultImport) {
-        prefix = `${this.defaultImport}, `;
-      } else if (this.areOnlyTypes) {
-        prefix = 'type ';
+    _assignmentLessImportString(): string {
+      if (this.declarationKeyword === 'import') {
+        return `import '${this.path}';`;
       }
+
+      return `${this.importFunction || 'require'}('${this.path}');`;
     }
 
-    const named = this.namedImports.map(({
-      localName,
-      importedName,
-      isType,
-    }: {
-      localName: string,
-      importedName: ?string,
-      isType?: boolean,
-    }): string => {
-      const typePrefix = isType && (!this.areOnlyTypes || this.defaultImport) ? 'type ' : '';
-      if (!importedName) {
-        return `${typePrefix}${localName}`;
+    _defaultImportString(maxLineLength: number, tab: string): string {
+      const { equals, value } = equalsAndValue({
+        declarationKeyword: this.declarationKeyword,
+        importFunction: this.importFunction,
+        path: this.path,
+      });
+
+      const line = `${this.declarationKeyword || ''} ${this.defaultImport || ''} ${equals} ${value}`;
+      if (!isLineTooLong(line, maxLineLength)) {
+        return line;
       }
-      return `${typePrefix}${importedName} as ${localName}`;
-    });
 
-    const namedOneLine = `{ ${named.join(', ')} }`;
-    const line = `${this.declarationKeyword || ''} ${prefix}${namedOneLine} ${equals} ${value}`;
-    if (!isLineTooLong(line, maxLineLength)) {
-      return line;
+      return `${this.declarationKeyword || ''} ${this.defaultImport || ''} ${equals}\n${tab}${value}`;
     }
 
-    const tabJoined = named.join(`,\n${tab}`);
-    const namedMultiLine = `{\n${tab}${tabJoined},\n}`;
-    return `${this.declarationKeyword || ''} ${prefix}${namedMultiLine} ${equals} ${value}`;
-  }
+    _namedImportString(maxLineLength: number, tab: string): string {
+      const { equals, value } = equalsAndValue({
+        declarationKeyword: this.declarationKeyword,
+        importFunction: this.importFunction,
+        path: this.path,
+      });
 
-  _clearImportStringCache() {
-    delete this.originalImportString;
-  }
+      let prefix = '';
+      if (this.declarationKeyword === 'import') {
+        if (this.defaultImport) {
+          prefix = `${this.defaultImport}, `;
+        } else if (this.areOnlyTypes) {
+          prefix = 'type ';
+        }
+      }
+
+      const named = this.namedImports.map(({
+        localName,
+        importedName,
+        isType,
+      }: {
+        localName: string,
+        importedName: ?string,
+        isType?: boolean,
+      }): string => {
+        const typePrefix = isType && (!this.areOnlyTypes || this.defaultImport) ? 'type ' : '';
+        if (!importedName) {
+          return `${typePrefix}${localName}`;
+        }
+        return `${typePrefix}${importedName} as ${localName}`;
+      });
+
+      const namedOneLine = `{ ${named.join(', ')} }`;
+      const line = `${this.declarationKeyword || ''} ${prefix}${namedOneLine} ${equals} ${value}`;
+      if (!isLineTooLong(line, maxLineLength)) {
+        return line;
+      }
+
+      const tabJoined = named.join(`,\n${tab}`);
+      const namedMultiLine = `{\n${tab}${tabJoined},\n}`;
+      return `${this.declarationKeyword || ''} ${prefix}${namedMultiLine} ${equals} ${value}`;
+    }
+
+    _clearImportStringCache() {
+      delete this.originalImportString;
+    }
 }

--- a/lib/ImportStatement.js
+++ b/lib/ImportStatement.js
@@ -9,9 +9,9 @@ function equalsAndValue({
   importFunction,
   path,
 }: {
-  declarationKeyword: ?string,
-  importFunction: ?string,
-  path: string,
+    declarationKeyword: ?string,
+    importFunction: ?string,
+    path: string,
   }): Object {
   if (declarationKeyword === 'import') {
     return { equals: 'from', value: `'${path}';` };
@@ -53,19 +53,19 @@ export default class ImportStatement {
     leadingContent,
     path,
   }: {
-    assignment?: ?string,
-    declarationKeyword?: ?string,
-    hasTypeKeyword?: ?boolean,
-    defaultImport?: ?string,
-    hasSideEffects: boolean,
-    importFunction?: ?string,
-    namedImports?: Array<Object>,
-    areOnlyTypes?: boolean,
-    originalImportString?: ?string,
-    isChangedNamedImport?: ?boolean,
-    leadingContent?: ?string,
-    path: string,
-  } = {}) {
+      assignment?: ?string,
+      declarationKeyword?: ?string,
+      hasTypeKeyword?: ?boolean,
+      defaultImport?: ?string,
+      hasSideEffects: boolean,
+      importFunction?: ?string,
+      namedImports?: Array<Object>,
+      areOnlyTypes?: boolean,
+      originalImportString?: ?string,
+      isChangedNamedImport?: ?boolean,
+      leadingContent?: ?string,
+      path: string,
+    } = {}) {
     this.assignment = assignment;
     this.declarationKeyword = declarationKeyword;
     this.hasTypeKeyword = hasTypeKeyword;
@@ -168,12 +168,12 @@ export default class ImportStatement {
   }
 
   /**
-    * @return {Array<String>} Array of all variables that this ImportStatement
-    *   imports.
-    */
-    variables(): Array<string> {
-      return [this.defaultImport, ...this.localNames()].filter(Boolean);
-    }
+   * @return {Array<String>} Array of all variables that this ImportStatement
+   *   imports.
+   */
+  variables(): Array<string> {
+    return [this.defaultImport, ...this.localNames()].filter(Boolean);
+  }
 
   toImportStrings(maxLineLength: number, tab: string): Array<string> {
     const strings = this._importStrings(maxLineLength, tab);
@@ -216,142 +216,142 @@ export default class ImportStatement {
   }
 
   /**
-    * Merge another ImportStatement into this one.
-    */
-    merge(importStatement: ImportStatement) {
-      if (
+  * Merge another ImportStatement into this one.
+  */
+  merge(importStatement: ImportStatement) {
+    if (
       importStatement.defaultImport &&
-        this.defaultImport !== importStatement.defaultImport
+      this.defaultImport !== importStatement.defaultImport
     ) {
-        this.defaultImport = importStatement.defaultImport;
-        this._clearImportStringCache();
-      }
+      this.defaultImport = importStatement.defaultImport;
+      this._clearImportStringCache();
+    }
 
-      if (
-        importStatement.isChangedNamedImport &&
-        this.isChangedNamedImport !== importStatement.isChangedNamedImport
-      ) {
-        this.isChangedNamedImport = importStatement.isChangedNamedImport;
-        this._clearImportStringCache();
-      }
+    if (
+      importStatement.isChangedNamedImport &&
+      this.isChangedNamedImport !== importStatement.isChangedNamedImport
+    ) {
+      this.isChangedNamedImport = importStatement.isChangedNamedImport;
+      this._clearImportStringCache();
+    }
 
-      if (
-        importStatement.hasSideEffects &&
-        this.hasSideEffects !== importStatement.hasSideEffects
-      ) {
-        // If a module is ever thought to have side-effects, then assume it does.
-        this.hasSideEffects = true;
-        this._clearImportStringCache();
-      }
+    if (
+      importStatement.hasSideEffects &&
+      this.hasSideEffects !== importStatement.hasSideEffects
+    ) {
+      // If a module is ever thought to have side-effects, then assume it does.
+      this.hasSideEffects = true;
+      this._clearImportStringCache();
+    }
 
-      if (importStatement.hasNamedImports()) {
-        this.namedImports = this.namedImports || [];
-        const originalNamedImports = this.namedImports.slice(0); // clone array
+    if (importStatement.hasNamedImports()) {
+      this.namedImports = this.namedImports || [];
+      const originalNamedImports = this.namedImports.slice(0); // clone array
 
-        let modified = false;
+      let modified = false;
 
-        importStatement.namedImports.forEach((named: Object) => {
-          const namedImport = originalNamedImports.find(({
-            localName,
-          }: {
-            localName: string,
-          }): boolean =>
-            localName === named.localName);
-          if (!namedImport) {
-            this.namedImports.push(named);
-            modified = true;
-            if (this.areOnlyTypes && !named.isType) {
-              this.areOnlyTypes = false;
-            }
+      importStatement.namedImports.forEach((named: Object) => {
+        const namedImport = originalNamedImports.find(({
+          localName,
+        }: {
+          localName: string,
+        }): boolean =>
+          localName === named.localName);
+        if (!namedImport) {
+          this.namedImports.push(named);
+          modified = true;
+          if (this.areOnlyTypes && !named.isType) {
+            this.areOnlyTypes = false;
           }
-        });
-        if (modified) {
-          this.namedImports.sort((a: Object, b: Object): number => {
-            if (a.localName < b.localName) {
-              return -1;
-            }
-            if (a.localName > b.localName) {
-              return 1;
-            }
-            return 0;
-          });
-          this._clearImportStringCache();
         }
-      }
-
-      if (this.declarationKeyword !== importStatement.declarationKeyword) {
-        this.declarationKeyword = importStatement.declarationKeyword;
+      });
+      if (modified) {
+        this.namedImports.sort((a: Object, b: Object): number => {
+          if (a.localName < b.localName) {
+            return -1;
+          }
+          if (a.localName > b.localName) {
+            return 1;
+          }
+          return 0;
+        });
         this._clearImportStringCache();
       }
     }
 
-    _assignmentLessImportString(): string {
-      if (this.declarationKeyword === 'import') {
-        return `import '${this.path}';`;
-      }
+    if (this.declarationKeyword !== importStatement.declarationKeyword) {
+      this.declarationKeyword = importStatement.declarationKeyword;
+      this._clearImportStringCache();
+    }
+  }
 
-      return `${this.importFunction || 'require'}('${this.path}');`;
+  _assignmentLessImportString(): string {
+    if (this.declarationKeyword === 'import') {
+      return `import '${this.path}';`;
     }
 
-    _defaultImportString(maxLineLength: number, tab: string): string {
-      const { equals, value } = equalsAndValue({
-        declarationKeyword: this.declarationKeyword,
-        importFunction: this.importFunction,
-        path: this.path,
-      });
+    return `${this.importFunction || 'require'}('${this.path}');`;
+  }
 
-      const line = `${this.declarationKeyword || ''} ${this.defaultImport || ''} ${equals} ${value}`;
-      if (!isLineTooLong(line, maxLineLength)) {
-        return line;
-      }
+  _defaultImportString(maxLineLength: number, tab: string): string {
+    const { equals, value } = equalsAndValue({
+      declarationKeyword: this.declarationKeyword,
+      importFunction: this.importFunction,
+      path: this.path,
+    });
 
-      return `${this.declarationKeyword || ''} ${this.defaultImport || ''} ${equals}\n${tab}${value}`;
+    const line = `${this.declarationKeyword || ''} ${this.defaultImport || ''} ${equals} ${value}`;
+    if (!isLineTooLong(line, maxLineLength)) {
+      return line;
     }
 
-    _namedImportString(maxLineLength: number, tab: string): string {
-      const { equals, value } = equalsAndValue({
-        declarationKeyword: this.declarationKeyword,
-        importFunction: this.importFunction,
-        path: this.path,
-      });
+    return `${this.declarationKeyword || ''} ${this.defaultImport || ''} ${equals}\n${tab}${value}`;
+  }
 
-      let prefix = '';
-      if (this.declarationKeyword === 'import') {
-        if (this.defaultImport) {
-          prefix = `${this.defaultImport}, `;
-        } else if (this.areOnlyTypes) {
-          prefix = 'type ';
-        }
+  _namedImportString(maxLineLength: number, tab: string): string {
+    const { equals, value } = equalsAndValue({
+      declarationKeyword: this.declarationKeyword,
+      importFunction: this.importFunction,
+      path: this.path,
+    });
+
+    let prefix = '';
+    if (this.declarationKeyword === 'import') {
+      if (this.defaultImport) {
+        prefix = `${this.defaultImport}, `;
+      } else if (this.areOnlyTypes) {
+        prefix = 'type ';
       }
-
-      const named = this.namedImports.map(({
-        localName,
-        importedName,
-        isType,
-      }: {
-        localName: string,
-        importedName: ?string,
-        isType?: boolean,
-      }): string => {
-        const typePrefix = isType && (!this.areOnlyTypes || this.defaultImport) ? 'type ' : '';
-        if (!importedName) {
-          return `${typePrefix}${localName}`;
-        }
-        return `${typePrefix}${importedName} as ${localName}`;
-      });
-
-      const namedOneLine = `{ ${named.join(', ')} }`;
-      const line = `${this.declarationKeyword || ''} ${prefix}${namedOneLine} ${equals} ${value}`;
-      if (!isLineTooLong(line, maxLineLength)) {
-        return line;
-      }
-
-      const tabJoined = named.join(`,\n${tab}`);
-      const namedMultiLine = `{\n${tab}${tabJoined}\n}`;
-      return `${this.declarationKeyword || ''} ${prefix}${namedMultiLine} ${equals} ${value}`;
     }
 
-    _clearImportStringCache() {
-      delete this.originalImportString;
+    const named = this.namedImports.map(({
+      localName,
+      importedName,
+      isType,
+    }: {
+      localName: string,
+      importedName: ?string,
+      isType?: boolean,
+    }): string => {
+      const typePrefix = isType && (!this.areOnlyTypes || this.defaultImport) ? 'type ' : '';
+      if (!importedName) {
+        return `${typePrefix}${localName}`;
+      }
+      return `${typePrefix}${importedName} as ${localName}`;
+    });
+
+    const namedOneLine = `{ ${named.join(', ')} }`;
+    const line = `${this.declarationKeyword || ''} ${prefix}${namedOneLine} ${equals} ${value}`;
+    if (!isLineTooLong(line, maxLineLength)) {
+      return line;
     }
+
+    const tabJoined = named.join(`,\n${tab}`);
+    const namedMultiLine = `{\n${tab}${tabJoined}\n}`;
+    return `${this.declarationKeyword || ''} ${prefix}${namedMultiLine} ${equals} ${value}`;
+  }
+
+  _clearImportStringCache() {
+    delete this.originalImportString;
+  }
 }

--- a/lib/ImportStatements.js
+++ b/lib/ImportStatements.js
@@ -47,8 +47,8 @@ GROUPINGS_ARRAY.forEach((group: string, index: number) => {
 Object.freeze(GROUPINGS);
 
 /**
-  * Determine import path type (e.g. 'package, 'non-relative', 'relative')
-  */
+ * Determine import path type (e.g. 'package, 'non-relative', 'relative')
+ */
 function importStatementPathType(
   importStatement: ImportStatement,
   packageDependencies: Set<string>,
@@ -68,9 +68,9 @@ function importStatementPathType(
   // (PATH_TYPE_PACKAGE).
   if (
     Array.from(packageDependencies)
-      .some((pkg: string): boolean =>
-        importStatement.path === pkg ||
-          importStatement.path.startsWith(`${pkg}/`))
+    .some((pkg: string): boolean =>
+      importStatement.path === pkg ||
+      importStatement.path.startsWith(`${pkg}/`))
   ) {
     return PATH_TYPE_PACKAGE;
   }
@@ -79,9 +79,9 @@ function importStatementPathType(
 }
 
 /**
-  * Determine import statement style (e.g. 'import', 'const', 'var', or
-  * 'custom')
-  */
+ * Determine import statement style (e.g. 'import', 'const', 'var', or
+ * 'custom')
+ */
 function importStatementStyle(importStatement: ImportStatement): string {
   if (importStatement.hasSideEffects) {
     return STYLE_SIDE_EFFECT;
@@ -158,6 +158,8 @@ export default class ImportStatements {
       if (existingStatement) {
         // Import already exists, so this line is likely one of a named imports
         // pair. Combine it into the same ImportStatement.
+        // eslint-disable-next-line no-param-reassign
+        importStatement.isChangedNamedImport = true;
         existingStatement.merge(importStatement);
       } else {
         // This is a new import, so we just add it to the hash.
@@ -204,10 +206,10 @@ export default class ImportStatements {
         const importStrings = importStatement
           .toImportStrings(maxLineLength, tab)
           .map((importString: string): string =>
-            this.config.get('importStatementFormatter', {
-              importStatement: importString,
-              moduleName: importStatement.path,
-            }));
+          this.config.get('importStatementFormatter', {
+            importStatement: importString,
+            moduleName: importStatement.path,
+          }));
         strings.push(...importStrings);
       });
       strings.push(''); // Add a blank line between groups.
@@ -230,7 +232,7 @@ export default class ImportStatements {
     const groups = [];
 
     const importsArray = Object.keys(this.imports)
-      .map((key: string): ImportStatement => this.imports[key]);
+    .map((key: string): ImportStatement => this.imports[key]);
 
     // There's a chance we have duplicate imports (can happen when switching
     // declaration_keyword for instance). By first sorting imports so that new
@@ -239,7 +241,7 @@ export default class ImportStatements {
     let result = partition(
       importsArray,
       (importStatement: ImportStatement): boolean =>
-        !importStatement.isParsedAndUntouched(),
+      !importStatement.isParsedAndUntouched(),
     );
     result = flattenDeep(result);
 

--- a/lib/ImportStatements.js
+++ b/lib/ImportStatements.js
@@ -47,8 +47,8 @@ GROUPINGS_ARRAY.forEach((group: string, index: number) => {
 Object.freeze(GROUPINGS);
 
 /**
- * Determine import path type (e.g. 'package, 'non-relative', 'relative')
- */
+  * Determine import path type (e.g. 'package, 'non-relative', 'relative')
+  */
 function importStatementPathType(
   importStatement: ImportStatement,
   packageDependencies: Set<string>,
@@ -68,9 +68,9 @@ function importStatementPathType(
   // (PATH_TYPE_PACKAGE).
   if (
     Array.from(packageDependencies)
-    .some((pkg: string): boolean =>
-      importStatement.path === pkg ||
-      importStatement.path.startsWith(`${pkg}/`))
+      .some((pkg: string): boolean =>
+        importStatement.path === pkg ||
+          importStatement.path.startsWith(`${pkg}/`))
   ) {
     return PATH_TYPE_PACKAGE;
   }
@@ -79,9 +79,9 @@ function importStatementPathType(
 }
 
 /**
- * Determine import statement style (e.g. 'import', 'const', 'var', or
- * 'custom')
- */
+  * Determine import statement style (e.g. 'import', 'const', 'var', or
+  * 'custom')
+  */
 function importStatementStyle(importStatement: ImportStatement): string {
   if (importStatement.hasSideEffects) {
     return STYLE_SIDE_EFFECT;
@@ -206,10 +206,10 @@ export default class ImportStatements {
         const importStrings = importStatement
           .toImportStrings(maxLineLength, tab)
           .map((importString: string): string =>
-          this.config.get('importStatementFormatter', {
-            importStatement: importString,
-            moduleName: importStatement.path,
-          }));
+            this.config.get('importStatementFormatter', {
+              importStatement: importString,
+              moduleName: importStatement.path,
+            }));
         strings.push(...importStrings);
       });
       strings.push(''); // Add a blank line between groups.
@@ -232,7 +232,7 @@ export default class ImportStatements {
     const groups = [];
 
     const importsArray = Object.keys(this.imports)
-    .map((key: string): ImportStatement => this.imports[key]);
+      .map((key: string): ImportStatement => this.imports[key]);
 
     // There's a chance we have duplicate imports (can happen when switching
     // declaration_keyword for instance). By first sorting imports so that new
@@ -241,7 +241,7 @@ export default class ImportStatements {
     let result = partition(
       importsArray,
       (importStatement: ImportStatement): boolean =>
-      !importStatement.isParsedAndUntouched(),
+        !importStatement.isParsedAndUntouched(),
     );
     result = flattenDeep(result);
 


### PR DESCRIPTION
When rearranging imports, because a new namedImport was added, merge conflicts can become confusing and 