### PR TITLE
Bugfix: resolving "toString" name causes a crush

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -3,6 +3,7 @@
 import crypto from 'crypto';
 import os from 'os';
 import path from 'path';
+import has from 'lodash/has';
 
 import globals from 'globals';
 import semver from 'semver';
@@ -291,10 +292,11 @@ export default class Configuration {
   }
 
   resolveAlias(variableName: string): ?string {
-    let importPath = this.get('aliases')[variableName];
-    if (!importPath) {
+    if (!has(this.get('aliases'), variableName)) {
       return null;
     }
+
+    let importPath = this.get('aliases')[variableName];
 
     importPath = importPath.path || importPath; // path may be an object
 


### PR DESCRIPTION
If you try to resolve an import for the `toString` name import-js crushes. For example this code leads to an error:

    warn(`Error: Missing ${toString(e.names)}`);

Error message:

    line    4:
    importPath.replace is not a function
    TypeError: importPath.replace is not a function
    at Configuration.resolveAlias (/home/user/e/import-js/build/Configuration.js:357:35)
    at /home/user/e/import-js/build/findJsModulesFor.js:130:24
    at new Promise (<anonymous>)
    at findJsModulesFor (/home/user/e/import-js/build/findJsModulesFor.js:128 :10)
    at /home/user/e/import-js/build/Importer.js:417:45
    at new Promise (<anonymous>)
    at Importer.findOneJsModule (/home/user/e/import-js/build/Importer.js:416:16)
    at /home/user/e/import-js/build/Importer.js:153:17
    at new Promise (<anonymous>)
    at Importer._import (/home/user/e/import-js/build/Importer.js:152:16)

It is because of an unsafe check for a property being in the `aliases` object.

There is another problem with the `toString` name: it is not added to the import statement automatically by a "fix" command. I haven't found the reason. Maybe it is a similar unsafe code somewhere?