### PR TITLE
Identify rest properties correctly in visitIdentifierNodes

### DIFF
--- a/lib/__tests__/findUndefinedIdentifiers-test.js
+++ b/lib/__tests__/findUndefinedIdentifiers-test.js
@@ -202,3 +202,10 @@ it('handles es6 imports + commonjs + react', () => {
     ['module'],
   )).toEqual(new Set(['themed', '$', 'CardHeader']));
 });
+
+it('knows about object rest', () => {
+  expect(findUndefinedIdentifiers(parse(`
+    let someObject = {};
+    const { a, ...theRest } = someObject;
+  `))).toEqual(new Set([]));
+});

--- a/lib/visitIdentifierNodes.js
+++ b/lib/visitIdentifierNodes.js
@@ -52,11 +52,11 @@ function normalizeNode(node, context) {
       };
     }
   }
-
   const isAssignment = KEYS_USED_FOR_ASSIGNMENT.has(key) ||
     (key === 'key' && parent.parent.type === 'ObjectPattern') ||
     (key === 'left' && parent.type === 'AssignmentPattern') ||
     (key === 'elements' && parent.type === 'ArrayPattern') ||
+    (key === 'argument' && parent.type === 'RestProperty') ||
     (key === 'value' &&
       parent.parent.type === 'ObjectPattern' &&
       parent.parent.parent.type === 'VariableDeclarator');


### PR DESCRIPTION
Fixes #512

Before this change, we would try to import `foo` in the following
context, even though it was a local assignment:

  const { ...foo } = {};