### PR TITLE
Allow imports to be appended.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The following configuration options are supported.
 - [`moduleNameFormatter`](#modulenameformatter)
 - [`namedExports`](#namedexports)
 - [`sortImports`](#sortimports)
+- [`appendImports`](#appendimports)
 - [`stripFileExtensions`](#stripfileextensions)
 - [`danglingCommas`](#danglingcommas)
 - [`tab`](#tab)
@@ -324,6 +325,9 @@ disabled, existing imports are not rearranged, and new imports are always added 
 ```javascript
 sortImports: false
 ```
+
+### `appendImports`
+When appendImports is true and sortImports and groupImports is false, you will have imports appear at the bottom of the import statements rather than the top.
 
 ### `emptyLineBetweenGroups`
 

--- a/lib/ImportStatements.js
+++ b/lib/ImportStatements.js
@@ -244,6 +244,11 @@ export default class ImportStatements {
       (importStatement: ImportStatement): boolean =>
         !importStatement.isParsedAndUntouched(),
     );
+
+    // appendImport only works when sortImports and groupImports is false
+    if (this.config.get('appendImports')) {
+      result.reverse();
+    }
     result = flattenDeep(result);
 
     if (this.config.get('sortImports')) {

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -484,6 +484,7 @@ foo
         beforeEach(() => {
           configuration.groupImports = false;
           configuration.sortImports = false;
+          configuration.appendImports = false;
         });
 
         it('leaves newlines', () => {
@@ -615,6 +616,22 @@ import bar from './bar';
  * 123
  */
 import baz from './bar/baz';
+
+foo
+          `.trim());
+        });
+        it('appends instead of prepends', () => {
+          configuration.appendImports = true;
+
+          text = `
+import bar from './bar';
+
+foo
+          `.trim();
+
+          expect(subject()).toEqual(`
+import bar from './bar';
+import foo from './bar/foo';
 
 foo
           `.trim());


### PR DESCRIPTION
Currently, if you have sortImports false, and groupImports false,
you will have imports appear at the top of the import list.

This is not ideal.
Now, there is a path forward which puts imports last instead of first.