### PR TITLE
Add option to use .importjs-root file to detect project root

### DIFF
--- a/lib/__tests__/findProjectRoot-test.js
+++ b/lib/__tests__/findProjectRoot-test.js
@@ -14,6 +14,8 @@ const normalPackageJsonContents = `{
   }
 }`;
 
+const emptyFile = '';
+
 it('finds the right folders', () => {
   // FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {
   fs.__setFile(path.join(path.resolve('/'), 'foo', 'package.json'), normalPackageJsonContents);
@@ -52,4 +54,10 @@ it('ignores directories in which the package.json specifies "importjs": { "isRoo
     }
   }`);
   expect(findProjectRoot(path.join('/', 'foo', 'bar', 'baz.js'))).toEqual(path.join(path.resolve('/'), 'foo'));
+});
+
+it('finds the folder with .importjs-root', () => {
+  fs.__setFile(path.join(path.resolve('/'), 'foo', '.importjs-root'), emptyFile);
+  expect(findProjectRoot(path.join(path.resolve('/'), 'foo', 'bar', 'baz.js')))
+    .toEqual(path.join(path.resolve('/'), 'foo'));
 });

--- a/lib/__tests__/initializeModuleFinder-test.js
+++ b/lib/__tests__/initializeModuleFinder-test.js
@@ -8,6 +8,6 @@ it('fails if required files are missing', () => {
       expect(true).toEqual(false); // we shouldn't end up here
     })
     .catch((error) => {
-      expect(error.message).toEqual(`ModuleFinder is disabled for ${bogusDir} (none of .importjs.js, package.json were found).`);
+      expect(error.message).toEqual(`ModuleFinder is disabled for ${bogusDir} (none of .importjs.js, package.json, .importjs-root were found).`);
     });
 });

--- a/lib/findProjectRoot.js
+++ b/lib/findProjectRoot.js
@@ -25,8 +25,9 @@ function findRecursive(directory) {
   }
 
   const pathToPackageJson = path.join(directory, 'package.json');
+  const pathToImportJs = path.join(directory, '.importjs-root');
 
-  if (isRootPackageJson(pathToPackageJson)) {
+  if (isRootPackageJson(pathToPackageJson) || fs.existsSync(pathToImportJs)) {
     return directory;
   }
 

--- a/lib/initializeModuleFinder.js
+++ b/lib/initializeModuleFinder.js
@@ -4,7 +4,7 @@ import path from 'path';
 import Configuration from './Configuration';
 import ModuleFinder from './ModuleFinder';
 
-const REQUIRED_FILES = ['.importjs.js', 'package.json'];
+const REQUIRED_FILES = ['.importjs.js', 'package.json', '.importjs-root'];
 
 const alreadyInitializedFinders = new Set();
 


### PR DESCRIPTION
As discussed in https://github.com/Galooshi/import-js/issues/546

This adds the option to create a file `.importjs-root` to allow for ImportJS to detect the root of the project.

This is useful for projects that don't have a `package.json`, such as those that use native ES modules only.

