### PR TITLE
Handle omitted array destructure

### DIFF
--- a/lib/__tests__/findUndefinedIdentifiers-test.js
+++ b/lib/__tests__/findUndefinedIdentifiers-test.js
@@ -214,3 +214,9 @@ it('knows about object rest', () => {
     const { a, ...theRest } = someObject;
   `))).toEqual(new Set([]));
 });
+
+it('can handle omitted array destructure', () => {
+  expect(findUndefinedIdentifiers(parse(`
+  const [,bar] = foo();
+  `))).toEqual(new Set(['foo']));
+});

--- a/lib/visitIdentifierNodes.js
+++ b/lib/visitIdentifierNodes.js
@@ -85,6 +85,9 @@ export default function visitIdentifierNodes(
 
   while (queue.length) {
     current = queue.shift();
+    if (!current.node) {
+      continue; // eslint-disable-line
+    }
     if (Array.isArray(current.node)) {
       if (current.context.key === 'body') {
         // A new scope has started. Copy whatever we have from the parent scope


### PR DESCRIPTION
I noticed importjs was crashing when I had this code:

  const [, item] = await db.Item.findByPk(id);

This code is valid, we just need to add some special-casing to ignore
the destructured omission.