### PR TITLE
require packageJson object

### DIFF
--- a/lib/findProjectRoot.js
+++ b/lib/findProjectRoot.js
@@ -12,7 +12,7 @@ function isRootPackageJson(path) {
 
   const packageJson = FileUtils.readJsonFile(path);
 
-  if ('importjs' in packageJson && 'isRoot' in packageJson.importjs) {
+  if (typeof packageJson === 'object' && 'importjs' in packageJson && 'isRoot' in packageJson.importjs) {
     return packageJson.importjs.isRoot;
   }
 


### PR DESCRIPTION
fix: importjs throws when `package.json` is an empty file
