### PR TITLE
Does not import React into JSX when version is gte 17

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -11,6 +11,7 @@ import semver from 'semver';
 import FileUtils from './FileUtils';
 import JsModule from './JsModule';
 import findPackageDependencies from './findPackageDependencies';
+import findDependencyVersion from './findDependencyVersion';
 import meteorEnvironment from './environments/meteorEnvironment';
 import nodeEnvironment from './environments/nodeEnvironment';
 import normalizePath from './normalizePath';
@@ -65,6 +66,14 @@ const DEFAULT_CONFIG = {
   danglingCommas: true,
   tab: '  ',
   useRelativePaths: true,
+  reactVersionLT17: ({ config }: Object): boolean => {
+    const reactVersion = findDependencyVersion(
+      'react',
+      config.workingDirectory,
+      config.get('importDevDependencies'),
+    );
+    return !!reactVersion && semver.lt(reactVersion, '17.0.0');
+  },
   packageDependencies: ({ config }: Object): Set<string> =>
     findPackageDependencies(
       config.workingDirectory,

--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -194,11 +194,13 @@ export default class Importer {
 
   // Removes unused imports and adds imports for undefined variables
   fixImports(): Promise<Object> {
+    const reactVersionLT17 = this.config.get('reactVersionLT17');
     const undefinedVariables = findUndefinedIdentifiers(
       this.ast,
       this.config.get('globals'),
+      reactVersionLT17,
     );
-    const usedVariables = findUsedIdentifiers(this.ast);
+    const usedVariables = findUsedIdentifiers(this.ast, reactVersionLT17);
     const oldImports = this.findCurrentImports();
     const newImports = oldImports.imports.clone();
 

--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -20,6 +20,7 @@ describe('Importer', () => {
   let existingFiles;
   let packageJsonContent;
   let packageDependencies;
+  let dependenciesVersions;
   let pathToCurrentFile;
   let configuration;
   let setup;
@@ -41,6 +42,7 @@ describe('Importer', () => {
     existingFiles = [];
     packageJsonContent = {};
     packageDependencies = [];
+    dependenciesVersions = { react: '16.0.0' };
 
     pathToCurrentFile = 'test.js';
     configuration = {};
@@ -63,7 +65,11 @@ describe('Importer', () => {
       // Convert the array to an object, as it is in the package.json file.
       const dependencies = packageDependencies.reduce(
         (depsObj, dependency) =>
-          Object.assign({}, depsObj, { [dependency]: '1.0.0' }),
+          Object.assign(
+            {},
+            depsObj,
+            { [dependency]: dependenciesVersions[dependency] || '1.0.0' },
+          ),
         {},
       );
       FileUtils.__setFile(path.join(process.cwd(), 'package.json'), {
@@ -2545,6 +2551,15 @@ const foo = <Foo/>;
         `.trim());
       });
 
+      it('does not import that component for react >=17.0.0', async () => {
+        dependenciesVersions = { react: '17.0.0' };
+        expect(await subject()).toEqual(`
+import Foo from './bar/foo';
+
+const foo = <Foo/>;
+        `.trim());
+      });
+
       it('displays a message', async () => {
         await subject();
         expect(result.messages).toEqual(["Imported Foo from './bar/foo'"]);
@@ -2565,6 +2580,15 @@ const foo = <Foo/>;
 
       it('does not remove any imports', async () => {
         expect(await subject()).toEqual(text);
+      });
+
+      it('does not remove React import for react >=17.0.0', async () => {
+        dependenciesVersions = { react: '~18.0.0' };
+        expect(await subject()).toEqual(`
+import Foo from 'bar/foo';
+
+const foo = <Foo/>;
+        `.trim());
       });
 
       it('does not display any message', async () => {
@@ -2600,6 +2624,13 @@ var a = <span/>;
         it('displays a message', async () => {
           await subject();
           expect(result.messages).toEqual(["Imported React from 'react'"]);
+        });
+
+        it('does not import React for react >= 17.0.0', async () => {
+          dependenciesVersions = { react: '^17.0.0' };
+          expect(await subject()).toEqual(`
+var a = <span/>;
+          `.trim());
         });
       });
     });

--- a/lib/__tests__/findUndefinedIdentifiers-test.js
+++ b/lib/__tests__/findUndefinedIdentifiers-test.js
@@ -4,6 +4,7 @@ import parse from '../parse';
 
 const local = subPath => path.resolve(__dirname, subPath);
 
+
 it('finds all undefined identifiers', () => {
   expect(findUndefinedIdentifiers(parse(`
     const foo = 'foo';
@@ -64,7 +65,7 @@ it('knows about dynamic keys', () => {
 it('knows about jsx', () => {
   expect(findUndefinedIdentifiers(parse(`
     export default <FooBar foo={bar} />;
-  `, local('foo.jsx')))).toEqual(new Set([
+  `, local('foo.jsx')), [], true)).toEqual(new Set([
     'bar',
     'React', // Implicit dependency
     'FooBar',
@@ -72,7 +73,7 @@ it('knows about jsx', () => {
 });
 
 it('ignores lowercase jsx element identifiers', () => {
-  expect(findUndefinedIdentifiers(parse("export default <input value='foo' />;", local('foo.jsx')))).toEqual(new Set([
+  expect(findUndefinedIdentifiers(parse("export default <input value='foo' />;", local('foo.jsx')), [], true)).toEqual(new Set([
     'React', // Implicit dependency
   ]));
 });
@@ -80,7 +81,7 @@ it('ignores lowercase jsx element identifiers', () => {
 it('knows about methods inside jsx', () => {
   expect(findUndefinedIdentifiers(parse(`
     <FooBar foo={(gar, car) => gar() + car()} />
-  `, local('foo.jsx')))).toEqual(new Set([
+  `, local('foo.jsx')), [], true)).toEqual(new Set([
     'React', // Implicit dependency
     'FooBar',
   ]));
@@ -89,7 +90,7 @@ it('knows about methods inside jsx', () => {
 it('knows about using an unconventional opening jsx tag', () => {
   expect(findUndefinedIdentifiers(parse(`
     <FooBar.Tar />
-  `, local('foo.jsx')))).toEqual(new Set([
+  `, local('foo.jsx')), [], true)).toEqual(new Set([
     'React', // Implicit dependency
     'FooBar',
   ]));
@@ -98,10 +99,19 @@ it('knows about using an unconventional opening jsx tag', () => {
 it('knows about fragment empty tag jsx syntax', () => {
   expect(findUndefinedIdentifiers(parse(`
     <FooBar><>{foo}</></FooBar>
-  `, local('foo.jsx')))).toEqual(new Set([
+  `, local('foo.jsx')), [], true)).toEqual(new Set([
     'React', // Implicit dependency
     'FooBar',
     'foo',
+  ]));
+});
+
+it('knows about jsx but does not import React for react >= 17.0.0', () => {
+  expect(findUndefinedIdentifiers(parse(`
+    export default <FooBar foo={bar} />;
+  `, local('foo.jsx')))).toEqual(new Set([
+    'bar',
+    'FooBar',
   ]));
 });
 

--- a/lib/__tests__/findUsedIdentifiers-test.js
+++ b/lib/__tests__/findUsedIdentifiers-test.js
@@ -16,7 +16,13 @@ it('finds used variables', () => {
 it('knows about jsx', () => {
   expect(findUsedIdentifiers(parse(`
     <Foo bar={far.foo()}/>
-  `, local('foo.jsx')))).toEqual(new Set(['far', 'React', 'Foo']));
+  `, local('foo.jsx')), true)).toEqual(new Set(['far', 'React', 'Foo']));
+});
+
+it('knows about jsx but does not import React for react >= 17.0.0', () => {
+  expect(findUsedIdentifiers(parse(`
+    <Foo bar={far.foo()}/>
+  `, local('foo.jsx')), true)).toEqual(new Set(['far', 'React', 'Foo']));
 });
 
 it('knows about flow annotations', () => {

--- a/lib/findDependencyVersion.js
+++ b/lib/findDependencyVersion.js
@@ -1,0 +1,28 @@
+// @flow
+import semver from 'semver';
+import path from 'path';
+
+import FileUtils from './FileUtils';
+
+/**
+ * Finds version of package from package.json
+ */
+export default function findDependencyVersion(
+  packageName: string,
+  workingDirectory: string,
+  includeDevDependencies: boolean,
+): ?string {
+  const packageJson = FileUtils.readJsonFile(path.join(workingDirectory, 'package.json'));
+  if (!packageJson) {
+    return null;
+  }
+  const keys = ['dependencies', 'peerDependencies'];
+  if (includeDevDependencies) {
+    keys.push('devDependencies');
+  }
+  const dependencyList = keys.map((key: string): any => packageJson[key]);
+  const mergedDependencies = Object.assign({}, ...dependencyList);
+  const rawVersion = mergedDependencies[packageName];
+  const ver = semver.coerce(rawVersion);
+  return ver && ver.version;
+}

--- a/lib/findUndefinedIdentifiers.js
+++ b/lib/findUndefinedIdentifiers.js
@@ -2,14 +2,18 @@ import visitIdentifierNodes from './visitIdentifierNodes';
 
 const JSX_BUILT_IN_ELEMENT_PATTERN = /^[a-z]/;
 
-export default function findUndefinedIdentifiers(ast, globalVariables = []) {
+export default function findUndefinedIdentifiers(
+  ast,
+  globalVariables = [],
+  reactVersionLT17 = false,
+) {
   const result = [];
   visitIdentifierNodes(
     ast.program,
     ({
       isReference, isJSX, name, context,
     }) => {
-      if (isJSX) {
+      if (isJSX && reactVersionLT17) {
         result.push({ name: 'React', context }); // Implicit dependency
       }
       if (isReference) {

--- a/lib/findUsedIdentifiers.js
+++ b/lib/findUsedIdentifiers.js
@@ -1,6 +1,6 @@
 import visitIdentifierNodes from './visitIdentifierNodes';
 
-export default function findUsedIdentifiers(ast) {
+export default function findUsedIdentifiers(ast, reactVersionLT17 = false) {
   const result = new Set();
   visitIdentifierNodes(ast.program, ({
     isAssignment,
@@ -8,7 +8,7 @@ export default function findUsedIdentifiers(ast) {
     isJSX,
     name,
   }) => {
-    if (isJSX) {
+    if (reactVersionLT17 && isJSX) {
       result.add('React');
     }
     if (!isReference && !isAssignment) {


### PR DESCRIPTION
As of react 17.0.0 it is not needed to import React into JSX files: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html. Added functionality to conditionally import React based on the react version in the package.json.