### PR TITLE
Configuration to also look for .importjs.cjs and .importjs.mjs

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -185,6 +185,22 @@ function mergedValue(values: Array<any>, key: string, options: Object): any {
   return mergedResult;
 }
 
+/**
+  * returns configuration from a JS file in home directory if it exists, or null
+  */
+function loadGlobalJsConfig(): ?Object {
+  for (let i = 0; i < JS_CONFIG_FILES.length; i += 1) {
+    const jsConfigFile = JS_CONFIG_FILES[i];
+    const globalConfig = FileUtils.readJsFile(path.join(os.homedir(), jsConfigFile));
+    if (globalConfig) {
+      return globalConfig;
+    }
+  }
+
+  return null;
+}
+
+
 // Class that initializes configuration from a .importjs.js file
 export default class Configuration {
   pathToCurrentFile: string;
@@ -266,14 +282,21 @@ export default class Configuration {
   }
 
   loadUserConfig(): ?Object {
-    for (const jsConfigFile of JS_CONFIG_FILES) {
+    return this.loadLocalJsConfig() ||
+      this.loadLocalJsonConfig() ||
+      loadGlobalJsConfig();
+  }
+
+  loadLocalJsConfig(): ?Object {
+    for (let i = 0; i < JS_CONFIG_FILES.length; i += 1) {
+      const jsConfigFile = JS_CONFIG_FILES[i];
       const jsConfig = FileUtils.readJsFile(path.join(this.workingDirectory, jsConfigFile));
 
       if (jsConfig && Object.keys(jsConfig).length === 0) {
         // If you forget to use `module.exports`, the config object will be `{}`.
         // To prevent subtle errors from happening, we surface an error message to
         // the user.
-        throw new Error(`Nothing exported from ${file}. You need to use \`module.exports\` to specify what gets exported from the file.`);
+        throw new Error(`Nothing exported from ${jsConfigFile}. You need to use \`module.exports\` to specify what gets exported from the file.`);
       }
 
       if (jsConfig) {
@@ -281,6 +304,10 @@ export default class Configuration {
       }
     }
 
+    return null;
+  }
+
+  loadLocalJsonConfig(): ?Object {
     const jsonConfig = FileUtils.readJsonFile(path.join(this.workingDirectory, JSON_CONFIG_FILE));
 
     if (jsonConfig) {
@@ -288,9 +315,7 @@ export default class Configuration {
       return jsonConfig;
     }
 
-    const globalConfig = FileUtils.readJsFile(path.join(os.homedir(), jsConfigFile));
-
-    return globalConfig;
+    return null;
   }
 
   resolveAlias(variableName: string): ?string {

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -17,7 +17,7 @@ import normalizePath from './normalizePath';
 import version from './version';
 
 const JSON_CONFIG_FILE = '.importjs.json';
-const JS_CONFIG_FILE = '.importjs.js';
+const JS_CONFIG_FILES = ['.importjs.js', '.importjs.cjs', '.importjs.mjs'];
 
 function findGlobalsFromEnvironments(environments: Array<string>): Array<string> {
   const result = Object.keys(globals.builtin);
@@ -266,17 +266,19 @@ export default class Configuration {
   }
 
   loadUserConfig(): ?Object {
-    const jsConfig = FileUtils.readJsFile(path.join(this.workingDirectory, JS_CONFIG_FILE));
+    for (const jsConfigFile of JS_CONFIG_FILES) {
+      const jsConfig = FileUtils.readJsFile(path.join(this.workingDirectory, jsConfigFile));
 
-    if (jsConfig && Object.keys(jsConfig).length === 0) {
-      // If you forget to use `module.exports`, the config object will be `{}`.
-      // To prevent subtle errors from happening, we surface an error message to
-      // the user.
-      throw new Error(`Nothing exported from ${JS_CONFIG_FILE}. You need to use \`module.exports\` to specify what gets exported from the file.`);
-    }
+      if (jsConfig && Object.keys(jsConfig).length === 0) {
+        // If you forget to use `module.exports`, the config object will be `{}`.
+        // To prevent subtle errors from happening, we surface an error message to
+        // the user.
+        throw new Error(`Nothing exported from ${file}. You need to use \`module.exports\` to specify what gets exported from the file.`);
+      }
 
-    if (jsConfig) {
-      return jsConfig;
+      if (jsConfig) {
+        return jsConfig;
+      }
     }
 
     const jsonConfig = FileUtils.readJsonFile(path.join(this.workingDirectory, JSON_CONFIG_FILE));
@@ -286,7 +288,7 @@ export default class Configuration {
       return jsonConfig;
     }
 
-    const globalConfig = FileUtils.readJsFile(path.join(os.homedir(), JS_CONFIG_FILE));
+    const globalConfig = FileUtils.readJsFile(path.join(os.homedir(), jsConfigFile));
 
     return globalConfig;
   }

--- a/lib/__tests__/Configuration-test.js
+++ b/lib/__tests__/Configuration-test.js
@@ -22,6 +22,30 @@ describe('Configuration', () => {
     version.__reset();
   });
 
+  describe('with a javascript CommonJS configuration file in root directory', () => {
+    beforeEach(() => {
+      FileUtils.__setFile(path.join(process.cwd(), '.importjs.cjs'), {
+        aliases: { bar: 'foo' },
+      });
+    });
+
+    it('is used', () => {
+      expect(new Configuration().get('aliases')).toEqual({ bar: 'foo' });
+    });
+  });
+
+  describe('with a javascript ESM configuration file in root directory', () => {
+    beforeEach(() => {
+      FileUtils.__setFile(path.join(process.cwd(), '.importjs.mjs'), {
+        aliases: { bar: 'foo' },
+      });
+    });
+
+    it('is used', () => {
+      expect(new Configuration().get('aliases')).toEqual({ bar: 'foo' });
+    });
+  });
+
   describe('with camelCased configuration', () => {
     beforeEach(() => {
       FileUtils.__setFile(path.join(process.cwd(), '.importjs.js'), {


### PR DESCRIPTION
When working on a project using ES modules (`"type": "module"`), and using a `.importjs.js` file, then there's an error

```
Unable to parse configuration file. Reason:                                                                                                                   
Error [ERR_REQUIRE_ESM]: require() of ES Module /.importjs.js from /lib/node_modules/import-js/build/FileUtils.js not supported.
.importjs.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename .importjs.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at Object.readJsFile (/import-js/build/FileUtils.js:35:12)
```

However, following the suggestion to rename the file into `.importjs.cjs` will fail because ImportJS does not look for that file.

That's what this PR fixes.