### PR TITLE
No more implicit React identifiers

### DIFF
--- a/lib/__tests__/Importer-test.js
+++ b/lib/__tests__/Importer-test.js
@@ -2705,8 +2705,6 @@ var b = bar + foo;
         packageDependencies = ['react'];
         existingFiles = ['bar/foo.jsx'];
         text = `
-import React from 'react';
-
 const foo = <Foo/>;
         `.trim();
       });
@@ -2714,8 +2712,6 @@ const foo = <Foo/>;
       it('imports that component', async () => {
         expect(await subject()).toEqual(
           `
-import React from 'react';
-
 import Foo from './bar/foo';
 
 const foo = <Foo/>;
@@ -2741,13 +2737,15 @@ const foo = <Foo/>;
         `.trim();
       });
 
-      it('does not remove any imports', async () => {
-        expect(await subject()).toEqual(text);
+      it('removes the React import', async () => {
+        expect(await subject()).toEqual(`import Foo from 'bar/foo';
+
+const foo = <Foo/>;`);
       });
 
-      it('does not display any message', async () => {
+      it('displays a message', async () => {
         await subject();
-        expect(result.messages).toEqual([]);
+        expect(result.messages).toEqual(['Removed `React`.']);
       });
     });
 
@@ -2767,19 +2765,17 @@ const foo = <Foo/>;
           packageDependencies = ['react'];
         });
 
-        it('imports React', async () => {
+        it('does not import React', async () => {
           expect(await subject()).toEqual(
             `
-import React from 'react';
-
 var a = <span/>;
           `.trim(),
           );
         });
 
-        it('displays a message', async () => {
+        it('does not display a message', async () => {
           await subject();
-          expect(result.messages).toEqual(["Imported React from 'react'"]);
+          expect(result.messages).toEqual([]);
         });
       });
     });

--- a/lib/__tests__/findUndefinedIdentifiers-test.js
+++ b/lib/__tests__/findUndefinedIdentifiers-test.js
@@ -113,13 +113,7 @@ it('knows about jsx', () => {
         local('foo.jsx'),
       ),
     ),
-  ).toEqual(
-    new Set([
-      'bar',
-      'React', // Implicit dependency
-      'FooBar',
-    ]),
-  );
+  ).toEqual(new Set(['bar', 'FooBar']));
 });
 
 it('ignores lowercase jsx element identifiers', () => {
@@ -127,11 +121,7 @@ it('ignores lowercase jsx element identifiers', () => {
     findUndefinedIdentifiers(
       parse("export default <input value='foo' />;", local('foo.jsx')),
     ),
-  ).toEqual(
-    new Set([
-      'React', // Implicit dependency
-    ]),
-  );
+  ).toEqual(new Set([]));
 });
 
 it('knows about methods inside jsx', () => {
@@ -144,12 +134,7 @@ it('knows about methods inside jsx', () => {
         local('foo.jsx'),
       ),
     ),
-  ).toEqual(
-    new Set([
-      'React', // Implicit dependency
-      'FooBar',
-    ]),
-  );
+  ).toEqual(new Set(['FooBar']));
 });
 
 it('knows about using an unconventional opening jsx tag', () => {
@@ -162,12 +147,7 @@ it('knows about using an unconventional opening jsx tag', () => {
         local('foo.jsx'),
       ),
     ),
-  ).toEqual(
-    new Set([
-      'React', // Implicit dependency
-      'FooBar',
-    ]),
-  );
+  ).toEqual(new Set(['FooBar']));
 });
 
 it('knows about fragment empty tag jsx syntax', () => {
@@ -180,13 +160,7 @@ it('knows about fragment empty tag jsx syntax', () => {
         local('foo.jsx'),
       ),
     ),
-  ).toEqual(
-    new Set([
-      'React', // Implicit dependency
-      'FooBar',
-      'foo',
-    ]),
-  );
+  ).toEqual(new Set(['FooBar', 'foo']));
 });
 
 it('knows about binary expression trees', () => {

--- a/lib/__tests__/findUsedIdentifiers-test.js
+++ b/lib/__tests__/findUsedIdentifiers-test.js
@@ -30,7 +30,7 @@ it('knows about jsx', () => {
         local('foo.jsx'),
       ),
     ),
-  ).toEqual(new Set(['far', 'React', 'Foo']));
+  ).toEqual(new Set(['far', 'Foo']));
 });
 
 it('knows about flow annotations', () => {

--- a/lib/findUndefinedIdentifiers.js
+++ b/lib/findUndefinedIdentifiers.js
@@ -7,9 +7,6 @@ export default function findUndefinedIdentifiers(ast, globalVariables = []) {
   visitIdentifierNodes(
     ast.program,
     ({ isReference, isJSX, name, context }) => {
-      if (isJSX) {
-        result.push({ name: 'React', context }); // Implicit dependency
-      }
       if (isReference) {
         return;
       }

--- a/lib/findUsedIdentifiers.js
+++ b/lib/findUsedIdentifiers.js
@@ -2,16 +2,10 @@ import visitIdentifierNodes from './visitIdentifierNodes';
 
 export default function findUsedIdentifiers(ast) {
   const result = new Set();
-  visitIdentifierNodes(
-    ast.program,
-    ({ isAssignment, isReference, isJSX, name }) => {
-      if (isJSX) {
-        result.add('React');
-      }
-      if (!isReference && !isAssignment) {
-        result.add(name);
-      }
-    },
-  );
+  visitIdentifierNodes(ast.program, ({ isAssignment, isReference, name }) => {
+    if (!isReference && !isAssignment) {
+      result.add(name);
+    }
+  });
   return result;
 }


### PR DESCRIPTION
Much inspiration from #580, thanks @madox2!

This PR never includes implicit React imports, unlike that PR. See issue for more information.

@trotzig Do you have some React projects where you could try this out in a sharp real-life environment? I don't do React, so I can't be too sure. All the tests are passing fine.