### PR TITLE
Provide the option to override parser plugins in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,54 @@ module.exports = {
 };
 ```
 
+### `parserPlugins`
+
+ImportJS defaults to a reasonable compromise for what syntax to support but can be overridden (replaced) in configuration. The latest defaults can be found [here](lib/parse.js#L3)
+
+Available plugins are over at [Babel: Plugins List](https://babeljs.io/docs/plugins-list)
+
+#### Example: Remove all preconfigured defaults
+
+```javascript
+parserPlugins: [] 
+```
+
+#### Example: Add pipeline operator (`hack` proposal)
+
+When `parserPlugins` is specified you need to re-add the defaults.
+
+```javascript
+parserPlugins: [
+  'jsx',
+  'doExpressions',
+  'objectRestSpread',
+  'decorators-legacy',
+  'classProperties',
+  'classPrivateProperties',
+  'classPrivateMethods',
+  'exportExtensions',
+  'asyncGenerators',
+  'functionBind',
+  'functionSent',
+  'dynamicImport',
+  'numericSeparator',
+  'optionalChaining',
+  'importMeta',
+  'bigInt',
+  'optionalCatchBinding',
+  'throwExpressions',
+  'nullishCoalescingOperator',
+  'exportNamespaceFrom',
+  'exportDefaultFrom',
+  [
+    'pipelineOperator',
+    {
+      proposal: 'hack',
+    },
+  ],
+]
+```
+
 ## Dynamic configuration
 
 Different sections of your application may have special importing needs. For

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -15,6 +15,7 @@ import meteorEnvironment from './environments/meteorEnvironment';
 import nodeEnvironment from './environments/nodeEnvironment';
 import normalizePath from './normalizePath';
 import version from './version';
+import { DEFAULT_PARSER_PLUGINS } from './parse.js';
 
 const JSON_CONFIG_FILE = '.importjs.json';
 const JS_CONFIG_FILES = ['.importjs.js', '.importjs.cjs', '.importjs.mjs'];
@@ -82,6 +83,7 @@ const DEFAULT_CONFIG = {
     namedExports: true,
     globals: true,
   },
+  parserPlugins: DEFAULT_PARSER_PLUGINS,
 };
 
 const KNOWN_CONFIGURATION_OPTIONS = [
@@ -110,6 +112,7 @@ const KNOWN_CONFIGURATION_OPTIONS = [
   'mergableOptions',
   'danglingCommas',
   'emptyLineBetweenGroups',
+  'parserPlugins',
 ];
 
 const DEPRECATED_CONFIGURATION_OPTIONS = [];

--- a/lib/Importer.js
+++ b/lib/Importer.js
@@ -12,7 +12,7 @@ import findCurrentImports from './findCurrentImports';
 import findJsModulesFor from './findJsModulesFor';
 import findUndefinedIdentifiers from './findUndefinedIdentifiers';
 import findUsedIdentifiers from './findUsedIdentifiers';
-import parse from './parse';
+import parse, { configureParserPlugins } from './parse';
 
 function fixImportsMessage(
   removedItems: Set<string>,
@@ -87,6 +87,8 @@ export default class Importer {
     this.editor = new CommandLineEditor(lines);
     this.config = new Configuration(this.pathToCurrentFile, workingDirectory);
     this.workingDirectory = workingDirectory;
+
+    configureParserPlugins(this.config.get('parserPlugins'));
 
     this.messages = Array.from(this.config.messages);
     this.unresolvedImports = {};

--- a/lib/__tests__/Configuration-test.js
+++ b/lib/__tests__/Configuration-test.js
@@ -98,6 +98,7 @@ describe('Configuration', () => {
         namedExports: true,
         globals: true,
       });
+      expect(configuration.get('parserPlugins')).toContain('jsx');
     });
 
     describe('with a JSON configuration file', () => {

--- a/lib/__tests__/parse-test.js
+++ b/lib/__tests__/parse-test.js
@@ -1,51 +1,49 @@
 import path from 'path';
-import parse from '../parse';
+import parse, { configureParserPlugins } from '../parse';
 
 const local = (subPath) => path.resolve(__dirname, subPath);
 
-it('knows about object rest spread', () => {
+it('infer typescript from file extension', () => {
   expect(() =>
     parse(
       `
-    const { a, b, ...c } = foo;
-    `,
-      local('foo,js'),
+        class Employee {
+          private name: string;
+        }
+      `,
+      local('foo.tsx'),
     ),
   ).not.toThrowError();
 });
 
-it('knows about decorators', () => {
+it('should understand Flow without being told to', () => {
   expect(() =>
     parse(
       `
-    @Awesome
-    class Foo {};
-    `,
-      local('foo,js'),
+        const a : string = "hello";
+      `,
+      local('foo.js'),
     ),
   ).not.toThrowError();
 });
 
-it('knows about class properties', () => {
-  expect(() =>
-    parse(
-      `
-    class Foo {
-      foo = 'bar';
-    }
-    `,
-      local('foo,js'),
-    ),
-  ).not.toThrowError();
-});
+it('should include plugins provided', () => {
+  configureParserPlugins([
+    [
+      'pipelineOperator',
+      {
+        proposal: 'hack',
+        topicToken: '%',
+      },
+    ],
+  ]);
 
-it('knows about dynamic imports', () => {
   expect(() =>
     parse(
       `
-    import('./foo').then(module => module());
-    `,
-      local('foo,js'),
+        "hello" |> console.log(%);
+      `,
+      local('foo.js'),
     ),
   ).not.toThrowError();
 });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,44 @@
 // @flow
+
+export const DEFAULT_PARSER_PLUGINS = [
+  'jsx',
+  'doExpressions',
+  'objectRestSpread',
+  'decorators-legacy',
+  'classProperties',
+  'classPrivateProperties',
+  'classPrivateMethods',
+  'exportExtensions',
+  'asyncGenerators',
+  'functionBind',
+  'functionSent',
+  'dynamicImport',
+  'numericSeparator',
+  'optionalChaining',
+  'importMeta',
+  'bigInt',
+  'optionalCatchBinding',
+  'throwExpressions',
+  [
+    'pipelineOperator',
+    {
+      proposal: 'minimal',
+    },
+  ],
+  'nullishCoalescingOperator',
+  'exportNamespaceFrom',
+  'exportDefaultFrom',
+];
+
 const TYPESCRIPT_FILE_PATH_REGEX = /\.tsx?$/;
+let parserPlugins = DEFAULT_PARSER_PLUGINS;
+
+export function configureParserPlugins(
+  newParserPlugins: Array<string | [string, Object]>,
+) {
+  parserPlugins = newParserPlugins;
+  return;
+}
 
 function getParserPlugins(
   absolutePathToFile: string,
@@ -8,36 +47,7 @@ function getParserPlugins(
     ? 'typescript'
     : 'flow';
 
-  return [
-    typePlugin,
-    'jsx',
-    'doExpressions',
-    'objectRestSpread',
-    'decorators-legacy',
-    'classProperties',
-    'classPrivateProperties',
-    'classPrivateMethods',
-    'exportExtensions',
-    'asyncGenerators',
-    'functionBind',
-    'functionSent',
-    'dynamicImport',
-    'numericSeparator',
-    'optionalChaining',
-    'importMeta',
-    'bigInt',
-    'optionalCatchBinding',
-    'throwExpressions',
-    [
-      'pipelineOperator',
-      {
-        proposal: 'minimal',
-      },
-    ],
-    'nullishCoalescingOperator',
-    'exportNamespaceFrom',
-    'exportDefaultFrom',
-  ];
+  return [typePlugin, ...parserPlugins];
 }
 
 export default function parse(

--- a/package.json
+++ b/package.json
@@ -22,7 +22,14 @@
     "type": "git",
     "url": "git+https://github.com/galooshi/import-js.git"
   },
-  "keywords": ["es6", "commonjs", "es2015", "ts", "typescript", "importing"],
+  "keywords": [
+    "es6",
+    "commonjs",
+    "es2015",
+    "ts",
+    "typescript",
+    "importing"
+  ],
   "author": "Henric Trotzig",
   "contributors": [
     {
@@ -73,8 +80,13 @@
   "jest": {
     "automock": false,
     "testEnvironment": "node",
-    "setupFiles": ["./setupJest.js"],
-    "testPathIgnorePatterns": ["<rootDir>/build/", "<rootDir>/node_modules/"]
+    "setupFiles": [
+      "./setupJest.js"
+    ],
+    "testPathIgnorePatterns": [
+      "<rootDir>/build/",
+      "<rootDir>/node_modules/"
+    ]
   },
   "prettier": {
     "singleQuote": true


### PR DESCRIPTION
Related to #571

This PR provides a new configuration key `parserPlugins` that allows the end-user to override or extend what babel parser plugins to use. See [README](https://github.com/Galooshi/import-js/pull/611/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R582) for example use.

This implementation uses a (nasty) singleton in parse.js to achieve the goal. While I'm not too happy about that, I have reasons;

I spent a long time trying to implement this by passing the values around from Configuration.js to its endpoint, parse.js. However, I ran into trouble doing so. As it turns out a lot of code is calling parse.js indirectly, such as `findExports` and even `meteorEnvironment` and `Configuration` itself. I tried to find all the cases but in the end I had hundreds of lines of code changed and 96 failed tests. Weird circular dependencies started showing up as well. In the end, I gave up on that strategy.