### PR TITLE
Disable codeclimate when env var is missing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,4 +19,5 @@ jobs:
       - name: Report coverage
         env:
           CODECLIMATE_REPO_TOKEN: ${{ secrets.CODECLIMATE_REPO_TOKEN }}
+        if: env.CODECLIMATE_REPO_TOKEN != ''
         run: npx codeclimate-test-reporter < coverage/lcov.info


### PR DESCRIPTION
When outside contributors, e.g. dependabot, pushes a PR, the CODECLIMATE_REPO_TOKEN env variable is not present (it's a secret defined on the github account). We can ignore the codeclimate report in these cases to let tests still pass.

An alternative option would be to make the codeclimate secret available to everyone, but that's not very safe.

Fixes #619